### PR TITLE
Added support for headers

### DIFF
--- a/src/Models/EmailMessage.cs
+++ b/src/Models/EmailMessage.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using RestSharp;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -43,7 +44,7 @@ namespace Mandrill
         public string from_email { get; set; }
         public string from_name { get; set; }
         public IEnumerable<EmailAddress> to { get; set; }
-        public string headers { get; set; }
+        public JsonObject headers { get; private set; }
         public bool track_opens { get; set; }
         public bool track_clicks { get; set; }
         public bool auto_text { get; set; }
@@ -73,6 +74,16 @@ namespace Mandrill
                 content = content
             };
             global_merge_vars.Add(mv);
+        }
+
+        public void AddHeader(string name, string value)
+        {
+            if (this.headers == null)
+            {
+                this.headers = new JsonObject();
+            }
+
+            this.headers[name] = value;
         }
 
         public void AddRecipientVariable(string recipient, string name, string content)


### PR DESCRIPTION
Using header as string didn't work - Mandrill returned an error.
JsonObject is serialized correctly by RestSharp.
Currently Mandrill supports Reply-To and X-\* headers
