### PR TITLE
Implemented /templates/list.json

### DIFF
--- a/src/Mandrill/Mandrill.csproj
+++ b/src/Mandrill/Mandrill.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Models\RenderedTemplate.cs" />
     <Compile Include="Models\Search.cs" />
     <Compile Include="Models\SearchResult.cs" />
+    <Compile Include="Models\TemplateInfo.cs" />
     <Compile Include="Models\UserInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Models\TemplateContent.cs" />

--- a/src/Mandrill/Models/TemplateInfo.cs
+++ b/src/Mandrill/Models/TemplateInfo.cs
@@ -1,0 +1,13 @@
+﻿namespace Mandrill.Models
+{
+    public class TemplateInfo
+    {
+        public string name;
+
+        public string code;
+
+        public string publish_code;
+
+        public string publish_name;
+    }
+}

--- a/src/Mandrill/Templates.cs
+++ b/src/Mandrill/Templates.cs
@@ -30,5 +30,19 @@ namespace Mandrill
                 return JSON.Parse<RenderedTemplate>(p.Result.Content);
             }, TaskContinuationOptions.ExecuteSynchronously);
         }
+
+        public Task<List<TemplateInfo>> ListTemplatesAsync()
+        {
+            const string path = "/templates/list.json";
+
+            return this.PostAsync(path, null).ContinueWith(
+                p => JSON.Parse<List<TemplateInfo>>(p.Result.Content),
+                TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        public List<TemplateInfo> ListTemplates()
+        {
+            return this.ListTemplatesAsync().Result;
+        }
     }
 }

--- a/tests/AppSettings.example.config
+++ b/tests/AppSettings.example.config
@@ -6,5 +6,6 @@
   <add key="ValidToEmail" value="test@test.com" />
   <add key="FromEmail" value="test@test.com" />
   <add key="TemplateExample" value="Test" />
+  <add key="TemplateCount" value="1" />
   <add key="UniqueExistingEmailSubject" value="Unique email subject to search"/>
 </appSettings>

--- a/tests/IntegrationTests/TemplatesTests.cs
+++ b/tests/IntegrationTests/TemplatesTests.cs
@@ -46,5 +46,22 @@ namespace Mandrill.Tests.IntegrationTests
             // Verify
             Assert.AreEqual(expected, result.html);
         }
+
+        [Test]
+        public void List_Templates_Returns_Correct_Count()
+        {
+            // Setup
+            var apiKey = ConfigurationManager.AppSettings["APIKey"];
+            var templateCount = int.Parse(ConfigurationManager.AppSettings["TemplateCount"]);
+
+            // Exercise
+            var api = new MandrillApi(apiKey);
+            var result = api.ListTemplates();
+
+            var expected = templateCount;
+
+            // Verify
+            Assert.AreEqual(expected, result.Count);
+        }
     }
 }

--- a/tests/Mandrill.Tests.csproj
+++ b/tests/Mandrill.Tests.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mandrill.Tests</RootNamespace>
     <AssemblyName>Mandrill.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
I implemented methods to get the list of all templates and added an integration test. Also I removed the  `<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>` from Mandrill.Tests.csproj since it does not require .NET 4.5 to run.
