### PR TITLE
Added EmailMessage.important property

### DIFF
--- a/src/Mandrill/Models/EmailMessage.cs
+++ b/src/Mandrill/Models/EmailMessage.cs
@@ -59,6 +59,7 @@ namespace Mandrill
         public bool preserve_recipients { get; set; }
         public string bcc_address { get; set; }
         public bool merge { get; set; }
+        public bool important { get; set; }
         public List<merge_var> global_merge_vars { get; private set; }
         public List<rcpt_merge_var> merge_vars { get; private set; }
         public IEnumerable<string> tags { get; set; }


### PR DESCRIPTION
This prop lets mandrill know to let a message jump to the front of the message queue...
http://help.mandrill.com/entries/23664027-Does-Mandrill-allow-me-to-prioritize-messages-

(Was using your public nuget so I thought I'd go this route instead of maintaining our own fork)
