### PR TITLE
Correctly deserialize soft-bounced WebHookMessageState

### DIFF
--- a/src/Mandrill/Models/WebHookEvent.cs
+++ b/src/Mandrill/Models/WebHookEvent.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
+using System.Runtime.Serialization;
 
 /* http://help.mandrill.com/entries/21738186-introduction-to-webhooks
    Simple MVC Controller example
@@ -36,6 +37,7 @@ namespace Mandrill
 		Spam,
 		Unsub,
 		Bounced,
+        [EnumMember(Value="soft-bounced")]
 		Soft_bounced
 	}
 

--- a/tests/IntegrationTests/WebHookTests.cs
+++ b/tests/IntegrationTests/WebHookTests.cs
@@ -84,5 +84,34 @@ namespace Mandrill.Tests.IntegrationTests
 			Assert.AreEqual (1,message.Clicks.Count);
 			Assert.AreEqual ("http://www.GitHub.com",message.Clicks[0].Url);
 		}
+
+        [Test]
+        public void Soft_Bounce_Deserialize()
+        {
+            string events_json = @"[{
+    ""event"": ""soft_bounce"",
+    ""msg"": {
+      ""ts"": 1365109999,
+      ""subject"": ""This an example webhook message"",
+      ""email"": ""example.webhook@mandrillapp.com"",
+      ""sender"": ""example.sender@mandrillapp.com"",
+      ""tags"": [
+        ""webhook-example""
+      ],
+      ""state"": ""soft-bounced"",
+      ""metadata"": {
+        ""user_id"": 111
+      },
+      ""_id"": ""exampleaaaaaaaaaaaaaaaaaaaaaaaaa"",
+      ""_version"": ""exampleaaaaaaaaaaaaaaa"",
+      ""bounce_description"": ""mailbox_full"",
+      ""bgtools_code"": 22,
+      ""diag"": ""smtp;552 5.2.2 Over Quota""
+    }
+  }]";
+            var events = JSON.Parse<List<WebHookEvent>>(events_json);
+            Assert.AreEqual(1, events.Count);
+            Assert.AreEqual(WebHookMessageState.Soft_bounced, events[0].Msg.State);
+        }
 	}
 }


### PR DESCRIPTION
Using the Mandrill test webhook, the state property can be "soft-bounced" - note the hyphen rather than underscore. Attempting to deserialize this to a WebHookMessageState Enum fails, since the enum value is Soft_bounced.
