### PR TITLE
Full support for adding templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Asychronous:
    2. Delete
  4. Templates
    1. Render
+   2. Add
+   3. Update
  5. Senders
    1. List
 	

--- a/src/Mandrill/Models/TemplateInfo.cs
+++ b/src/Mandrill/Models/TemplateInfo.cs
@@ -7,6 +7,10 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
 namespace Mandrill.Models
 {
     /// <summary>
@@ -17,24 +21,113 @@ namespace Mandrill.Models
         #region Fields
 
         /// <summary>
-        /// The code.
+        /// The immutable unique code name of the template.
         /// </summary>
-        public string code;
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
 
         /// <summary>
-        /// The name.
+        /// The name of the template.
         /// </summary>
-        public string name;
+        [JsonProperty("name")]
+        public string name { get; set; }
 
         /// <summary>
-        /// The publish_code.
+        /// The list of labels applied to the template.
         /// </summary>
-        public string publish_code;
+        [JsonProperty("labels")]
+        public IEnumerable<string> Labels { get; set; }
 
         /// <summary>
-        /// The publish_name.
+        /// The full HTML code of the template, with <c>mc:edit</c> attributes
+        /// marking the editable elements.
         /// </summary>
-        public string publish_name;
+        [JsonProperty("code")]
+        public string code { get; set; }
+
+        /// <summary>
+        /// The subject line of the template, if provided.
+        /// </summary>
+        [JsonProperty("subject")]
+        public string Subject { get; set; }
+
+        /// <summary>
+        /// The default sender address for the template, if provided.
+        /// </summary>
+        [JsonProperty("from_email")]
+        public string FromEmail { get; set; }
+
+        /// <summary>
+        /// The default sender from name for the template, if provided.
+        /// </summary>
+        [JsonProperty("from_name")]
+        public string FromName { get; set; }
+
+        /// <summary>
+        /// The default text part of messages sent with the template, if provided.
+        /// </summary>
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+        /// <summary>
+        /// The same as the template name - kept as a separate field for
+        /// backwards compatibility.
+        /// </summary>
+        /// <seealso cref="Name"/>
+        [JsonProperty("publish_name")]
+        public string publish_name { get; set; }
+
+        /// <summary>
+        /// The full HTML code of the template, with <c>mc:edit</c> attributes
+        /// marking the editable elements that are available as published, if
+        /// it has been published.
+        /// </summary>
+        [JsonProperty("publish_code")]
+        public string publish_code { get; set; }
+
+        /// <summary>
+        /// The subject line of the template, if provided.
+        /// </summary>
+        [JsonProperty("publish_subject")]
+        public string PublishSubject { get; set; }
+
+        /// <summary>
+        /// The default sender address for the template, if provided.
+        /// </summary>
+        [JsonProperty("publish_from_email")]
+        public string PublishFromEmail { get; set; }
+
+        /// <summary>
+        /// The default sender from name for the template, if provided.
+        /// </summary>
+        [JsonProperty("publish_from_name")]
+        public string PublishFromName { get; set; }
+
+        /// <summary>
+        /// The default text part of messages sent with the template, if
+        /// provided.
+        /// </summary>
+        [JsonProperty("publish_text")]
+        public string PublishText { get; set; }
+
+        /// <summary>
+        /// The date and time the template was last published, or null if it
+        /// has not been published.
+        /// </summary>
+        [JsonProperty("published_at")]
+        public DateTime Published { get; set; }
+
+        /// <summary>
+        /// The date and time the template was first created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime Created { get; set; }
+
+        /// <summary>
+        /// The date and time the template was last modified.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public DateTime Updated { get; set; }
 
         #endregion
     }

--- a/src/Mandrill/Templates.cs
+++ b/src/Mandrill/Templates.cs
@@ -11,6 +11,7 @@ namespace Mandrill
 {
     using System.Collections.Generic;
     using System.Dynamic;
+    using System.Linq;
     using System.Threading.Tasks;
 
     using Mandrill.Models;
@@ -47,7 +48,7 @@ namespace Mandrill
 
             return this.PostAsync(path, null)
                 .ContinueWith(
-                    p => JSON.Parse<List<TemplateInfo>>(p.Result.Content), 
+                    p => JSON.Parse<List<TemplateInfo>>(p.Result.Content),
                     TaskContinuationOptions.ExecuteSynchronously);
         }
 
@@ -67,8 +68,8 @@ namespace Mandrill
         /// The <see cref="RenderedTemplate"/>.
         /// </returns>
         public RenderedTemplate Render(
-            string templateName, 
-            IEnumerable<TemplateContent> templateContents, 
+            string templateName,
+            IEnumerable<TemplateContent> templateContents,
             IEnumerable<merge_var> mergeVars)
         {
             return this.RenderAsync(templateName, templateContents, mergeVars).Result;
@@ -90,8 +91,8 @@ namespace Mandrill
         /// The <see cref="Task"/>.
         /// </returns>
         public Task<RenderedTemplate> RenderAsync(
-            string templateName, 
-            IEnumerable<TemplateContent> templateContents, 
+            string templateName,
+            IEnumerable<TemplateContent> templateContents,
             IEnumerable<merge_var> mergeVars)
         {
             const string path = "/templates/render.json";
@@ -105,20 +106,172 @@ namespace Mandrill
             Task<IRestResponse> post = this.PostAsync(path, payload);
 
             return post.ContinueWith(
-                p => { return JSON.Parse<RenderedTemplate>(p.Result.Content); }, 
+                p => { return JSON.Parse<RenderedTemplate>(p.Result.Content); },
                 TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        public object AddTemplate(object data)
+        /// <summary>
+        /// Add a new template.
+        /// </summary>
+        /// <param name="name">
+        /// The name for the new template - must be unique.
+        /// </param>
+        /// <param name="fromEmail">
+        /// A default sending address for emails sent using this template.
+        /// </param>
+        /// <param name="fromName">A default from name to be used.</param>
+        /// <param name="subject">A default subject line to be used.</param>
+        /// <param name="code">
+        /// The HTML code for the template with <c>mc:edit</c> attributes for
+        /// the editable elements.
+        /// </param>
+        /// <param name="text">
+        /// A default text part to be used when sending with this template.
+        /// </param>
+        /// <param name="publish">
+        /// Set to false to add a draft template without publishing.
+        /// </param>
+        /// <param name="labels">
+        /// Array of up to 10 labels to use for filtering templates.
+        /// </param>
+        /// <returns>A <see cref="TemplateResponse"/> object.</returns>
+        public TemplateInfo AddTemplate(
+            string name,
+            string fromEmail,
+            string fromName,
+            string subject,
+            string code,
+            string text,
+            bool publish,
+            IEnumerable<string> labels)
         {
-            return this.AddTemplateAsync(data).Result;
+            return this.AddTemplateAsync(name, fromEmail, fromName, subject, code, text, publish, labels).Result;
         }
 
-        public Task<object> AddTemplateAsync(object data)
+        /// <summary>
+        /// Add a new template.
+        /// </summary>
+        /// <param name="name">
+        /// The name for the new template - must be unique.
+        /// </param>
+        /// <param name="fromEmail">
+        /// A default sending address for emails sent using this template.
+        /// </param>
+        /// <param name="fromName">A default from name to be used.</param>
+        /// <param name="subject">A default subject line to be used.</param>
+        /// <param name="code">
+        /// The HTML code for the template with <c>mc:edit</c> attributes for
+        /// the editable elements.
+        /// </param>
+        /// <param name="text">
+        /// A default text part to be used when sending with this template.
+        /// </param>
+        /// <param name="publish">
+        /// Set to false to add a draft template without publishing.
+        /// </param>
+        /// <returns>A <see cref="TemplateResponse"/> object.</returns>
+        public TemplateInfo AddTemplate(
+            string name,
+            string fromEmail,
+            string fromName,
+            string subject,
+            string code,
+            string text,
+            bool publish)
+        {
+            return this.AddTemplateAsync(name, fromEmail, fromName, subject, code, text, publish, Enumerable.Empty<string>()).Result;
+        }
+
+        /// <summary>
+        /// Add a new template asynchronously.
+        /// </summary>
+        /// <param name="name">
+        /// The name for the new template - must be unique.
+        /// </param>
+        /// <param name="fromEmail">
+        /// A default sending address for emails sent using this template.
+        /// </param>
+        /// <param name="fromName">A default from name to be used.</param>
+        /// <param name="subject">A default subject line to be used.</param>
+        /// <param name="code">
+        /// The HTML code for the template with <c>mc:edit</c> attributes for
+        /// the editable elements.
+        /// </param>
+        /// <param name="text">
+        /// A default text part to be used when sending with this template.
+        /// </param>
+        /// <param name="published">
+        /// Set to false to add a draft template without publishing.
+        /// </param>
+        /// <returns>A <see cref="TemplateResponse"/> object.</returns>
+        public Task<TemplateInfo> AddTemplateAsync(
+            string name,
+            string fromEmail,
+            string fromName,
+            string subject,
+            string code,
+            string text,
+            bool publish)
+        {
+            return this.AddTemplateAsync(name, fromEmail, fromName, subject, code, text, publish, Enumerable.Empty<string>());
+        }
+
+        /// <summary>
+        /// Add a new template asynchronously.
+        /// </summary>
+        /// <param name="name">
+        /// The name for the new template - must be unique.
+        /// </param>
+        /// <param name="fromEmail">
+        /// A default sending address for emails sent using this template.
+        /// </param>
+        /// <param name="fromName">A default from name to be used.</param>
+        /// <param name="subject">A default subject line to be used.</param>
+        /// <param name="code">
+        /// The HTML code for the template with <c>mc:edit</c> attributes for
+        /// the editable elements.
+        /// </param>
+        /// <param name="text">
+        /// A default text part to be used when sending with this template.
+        /// </param>
+        /// <param name="published">
+        /// Set to false to add a draft template without publishing.
+        /// </param>
+        /// <param name="labels">
+        /// Array of up to 10 labels to use for filtering templates.
+        /// </param>
+        /// <returns>A <see cref="TemplateResponse"/> object.</returns>
+        public Task<TemplateInfo> AddTemplateAsync(
+            string name,
+            string fromEmail,
+            string fromName,
+            string subject,
+            string code,
+            string text,
+            bool publish,
+            IEnumerable<string> labels)
         {
             const string path = "/templates/add.json";
-            return this.PostAsync(path, data).ContinueWith(
-                p => JSON.Parse<object>(p.Result.Content),
+
+            dynamic payload = new ExpandoObject();
+
+            payload.name = name;
+            payload.from_email = fromEmail;
+            payload.from_name = fromName;
+            payload.subject = subject;
+            payload.code = code;
+            payload.text = text;
+            payload.publish = publish;
+
+            if (!labels.Equals(Enumerable.Empty<string>()))
+            {
+                payload.labels = labels;
+            }
+
+            Task<IRestResponse> post = PostAsync(path, payload);
+
+            return post.ContinueWith(
+                p => { return JSON.Parse<TemplateInfo>(p.Result.Content); },
                 TaskContinuationOptions.ExecuteSynchronously);
         }
 


### PR DESCRIPTION
Added full support for adding templates.
#41 beat me to the pull request so I modified from master to update the add process to specifically list out the parameters instead of accepting a generic `object`. Also modified the `TemplateInfo` class to support all fields sent from Mandrill on a template response.
