### PR TITLE
Add ability to set timeout for REST client

### DIFF
--- a/src/Mandrill/MandrillApi.cs
+++ b/src/Mandrill/MandrillApi.cs
@@ -50,20 +50,15 @@ namespace Mandrill
 
             if (useSsl)
             {
-                this.client = new RestClient(Configuration.BASE_SECURE_URL)
-                {
-                    Timeout = timeout
-                };
+                this.client = new RestClient(Configuration.BASE_SECURE_URL);
             }
             else
             {
-                this.client = new RestClient(Configuration.BASE_URL)
-                {
-                    Timeout = timeout
-                };
+                this.client = new RestClient(Configuration.BASE_URL);
             }
 
             this.client.AddHandler("application/json", new DynamicJsonDeserializer());
+            this.client.Timeout = timeout;
         }
 
         #endregion


### PR DESCRIPTION
Adds an additional optional parameter to the `MandrillApi` constructor. By default it's set to copy `RestClient.Timeout` which is zero (effectively no timeout).
