### PR TITLE
Add support for template deletion, add proper params for update

### DIFF
--- a/src/Mandrill/IMandrillApi.cs
+++ b/src/Mandrill/IMandrillApi.cs
@@ -571,9 +571,109 @@ namespace Mandrill
             IEnumerable<TemplateContent> templateContents,
             IEnumerable<merge_var> mergeVars);
 
-        object UpdateTemplate(object data);
+        /// <summary>
+        ///     Update the code for an existing template.
+        /// </summary>
+        /// <param name="name">
+        ///     The template name.
+        /// </param>
+        /// <param name="fromEmail">
+        ///     A default sending address for emails sent using this template.
+        /// </param>
+        /// <param name="fromName">A default from name to be used.</param>
+        /// <param name="subject">A default subject line to be used.</param>
+        /// <param name="code">
+        ///     The HTML code for the template with <c>mc:edit</c> attributes for
+        ///     the editable elements.
+        /// </param>
+        /// <param name="text">
+        ///     A default text part to be used when sending with this template.
+        /// </param>
+        /// <param name="publish">
+        ///     Set to false to update a draft template without publishing.
+        /// </param>
+        /// <param name="labels">
+        ///     Array of up to 10 labels to use for filtering templates.
+        /// </param>
+        /// <remarks>
+        ///     If <c>null</c> is provided for any fields, the values will remain unchanged.
+        /// </remarks>
+        /// <returns>
+        ///     The <see cref="TemplateInfo"/> object of the template that was updated 
+        /// </returns>
+        TemplateInfo UpdateTemplate(
+            string name,
+            string fromEmail,
+            string fromName,
+            string subject,
+            string code,
+            string text,
+            bool? publish,
+            IEnumerable<string> labels);
 
-        Task<object> UpdateTemplateAsync(object data);
+        /// <summary>
+        ///     Update the code for an existing template, asynchronously.
+        /// </summary>
+        /// <param name="name">
+        ///     The template name.
+        /// </param>
+        /// <param name="fromEmail">
+        ///     A default sending address for emails sent using this template.
+        /// </param>
+        /// <param name="fromName">A default from name to be used.</param>
+        /// <param name="subject">A default subject line to be used.</param>
+        /// <param name="code">
+        ///     The HTML code for the template with <c>mc:edit</c> attributes for
+        ///     the editable elements.
+        /// </param>
+        /// <param name="text">
+        ///     A default text part to be used when sending with this template.
+        /// </param>
+        /// <param name="publish">
+        ///     Set to false to update a draft template without publishing.
+        /// </param>
+        /// <param name="labels">
+        ///     Array of up to 10 labels to use for filtering templates.
+        /// </param>
+        /// <remarks>
+        ///     If <c>null</c> is provided for any fields, the values will remain unchanged.
+        /// </remarks>
+        /// <returns>
+        ///     The <see cref="TemplateInfo"/> object of the template that was updated
+        /// </returns>
+        Task<TemplateInfo> UpdateTemplateAsync(
+            string name,
+            string fromEmail,
+            string fromName,
+            string subject,
+            string code,
+            string text,
+            bool? publish,
+            IEnumerable<string> labels);
+
+        /// <summary>
+        ///     Delete a template.
+        /// </summary>
+        /// <param name="name">
+        ///     The template name.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="TemplateInfo"/> object of the template that was deleted
+        /// </returns>
+        TemplateInfo DeleteTemplate(
+            string name);
+
+        /// <summary>
+        ///     Delete a template, asynchronously.
+        /// </summary>
+        /// <param name="name">
+        ///     The template name.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="TemplateInfo"/> object of the template that was deleted
+        /// </returns>
+        Task<TemplateInfo> DeleteTemplateAsync(
+            string name);
 
         /// <summary>
         ///     Add a new subaccount.

--- a/src/Mandrill/Templates.cs
+++ b/src/Mandrill/Templates.cs
@@ -330,16 +330,147 @@ namespace Mandrill
                 TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        public object UpdateTemplate(object data)
+        /// <summary>
+        ///     Update the code for an existing template.
+        /// </summary>
+        /// <param name="name">
+        ///     The template name.
+        /// </param>
+        /// <param name="fromEmail">
+        ///     A default sending address for emails sent using this template.
+        /// </param>
+        /// <param name="fromName">A default from name to be used.</param>
+        /// <param name="subject">A default subject line to be used.</param>
+        /// <param name="code">
+        ///     The HTML code for the template with <c>mc:edit</c> attributes for
+        ///     the editable elements.
+        /// </param>
+        /// <param name="text">
+        ///     A default text part to be used when sending with this template.
+        /// </param>
+        /// <param name="publish">
+        ///     Set to false to update a draft template without publishing.
+        /// </param>
+        /// <param name="labels">
+        ///     Array of up to 10 labels to use for filtering templates.
+        /// </param>
+        /// <remarks>
+        ///     If <c>null</c> is provided for any fields, the values will remain unchanged.
+        /// </remarks>
+        /// <returns>
+        ///     The <see cref="TemplateInfo"/> object of the template that was updated 
+        /// </returns>
+        public TemplateInfo UpdateTemplate(
+            string name,
+            string fromEmail,
+            string fromName,
+            string subject,
+            string code,
+            string text,
+            bool? publish,
+            IEnumerable<string> labels)
         {
-            return this.UpdateTemplateAsync(data).Result;
+            return this.UpdateTemplateAsync(name, fromEmail, fromName, subject, code, text, publish, labels).Result;
         }
 
-        public Task<object> UpdateTemplateAsync(object data)
+        /// <summary>
+        ///     Update the code for an existing template, asynchronously.
+        /// </summary>
+        /// <param name="name">
+        ///     The template name.
+        /// </param>
+        /// <param name="fromEmail">
+        ///     A default sending address for emails sent using this template.
+        /// </param>
+        /// <param name="fromName">A default from name to be used.</param>
+        /// <param name="subject">A default subject line to be used.</param>
+        /// <param name="code">
+        ///     The HTML code for the template with <c>mc:edit</c> attributes for
+        ///     the editable elements.
+        /// </param>
+        /// <param name="text">
+        ///     A default text part to be used when sending with this template.
+        /// </param>
+        /// <param name="publish">
+        ///     Set to false to update a draft template without publishing.
+        /// </param>
+        /// <param name="labels">
+        ///     Array of up to 10 labels to use for filtering templates.
+        /// </param>
+        /// <remarks>
+        ///     If <c>null</c> is provided for any fields, the values will remain unchanged.
+        /// </remarks>
+        /// <returns>
+        ///     The <see cref="TemplateInfo"/> object of the template that was updated 
+        /// </returns>
+        public Task<TemplateInfo> UpdateTemplateAsync(
+            string name,
+            string fromEmail,
+            string fromName,
+            string subject,
+            string code,
+            string text,
+            bool? publish,
+            IEnumerable<string> labels)
         {
             const string path = "/templates/update.json";
-            return this.PostAsync(path, data)
-                .ContinueWith(p => JSON.Parse<object>(p.Result.Content), TaskContinuationOptions.ExecuteSynchronously);
+
+            dynamic payload = new ExpandoObject();
+
+            payload.name = name;
+            payload.from_email = fromEmail;
+            payload.from_name = fromName;
+            payload.subject = subject;
+            payload.code = code;
+            payload.text = text;
+            payload.publish = publish;
+            payload.labels = labels;
+
+            Task<IRestResponse> post = this.PostAsync(path, payload);
+
+            return post.ContinueWith(
+                p => JSON.Parse<TemplateInfo>(p.Result.Content),
+                TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        /// <summary>
+        ///     Delete a template.
+        /// </summary>
+        /// <param name="name">
+        ///     The template name.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="TemplateInfo"/> object of the template that was deleted
+        /// </returns>
+        public TemplateInfo DeleteTemplate(
+            string name)
+        {
+            return this.DeleteTemplateAsync(name).Result;
+        }
+
+        /// <summary>
+        ///     Delete a template, asynchronously.
+        /// </summary>
+        /// <param name="name">
+        ///     The template name.
+        /// </param>
+        /// <returns>
+        ///     The <see cref="TemplateInfo"/> object of the template that was deleted
+        /// </returns>
+        public Task<TemplateInfo> DeleteTemplateAsync(
+            string name)
+        {
+            const string path = "/templates/delete.json";
+
+            dynamic payload = new ExpandoObject();
+
+            payload.name = name;
+
+            Task<IRestResponse> post = this.PostAsync(path, payload);
+
+            return post.ContinueWith(
+                p => JSON.Parse<TemplateInfo>(p.Result.Content),
+                TaskContinuationOptions.ExecuteSynchronously);
         }
 
         #endregion

--- a/tests/IntegrationTests/TemplatesTests.cs
+++ b/tests/IntegrationTests/TemplatesTests.cs
@@ -80,5 +80,56 @@ namespace Mandrill.Tests.IntegrationTests
             // Verify
             Assert.AreEqual(expected, result.Count);
         }
+
+        [Test]
+        public void Can_Update_Template()
+        {
+            // Setup
+            var apiKey = ConfigurationManager.AppSettings["APIKey"];
+            var templateName = ConfigurationManager.AppSettings["TemplateExample"];
+            const string original = "<span mc:edit=\"model1\"></span>";
+            const string modified = "<span mc:edit=\"model2\"></span>";
+
+            // Exercise
+            var api = new MandrillApi(apiKey);
+            var result = api.UpdateTemplate(templateName,
+                "test@test.invalid",
+                "Test",
+                "Template test",
+                modified,
+                "*|model1|*",
+                true,
+                null);
+            var result2 = api.UpdateTemplate(templateName,
+                "test@test.invalid",
+                "Test",
+                "Template test",
+                original,
+                "*|model1|*",
+                true,
+                null);
+
+            // Verify
+            Assert.AreEqual(modified, result.code);
+            Assert.AreEqual(original, result2.code);
+        }
+
+        [Test]
+        public void Can_Create_And_Delete_Template()
+        {
+            // Setup
+            var apiKey = ConfigurationManager.AppSettings["APIKey"];
+            var templateName = ConfigurationManager.AppSettings["TemplateExample"] + "_temp";
+            const string code = "Foobar";
+
+            // Exercise
+            var api = new MandrillApi(apiKey);
+            var result = api.AddTemplate(templateName, "test@test.invalid", "Test", "Template test", code, code, true);
+            var result2 = api.DeleteTemplate(templateName);
+
+            // Verify
+            Assert.AreEqual(code, result.code);
+            Assert.AreEqual(code, result2.code);
+        }
     }
 }


### PR DESCRIPTION
Added `DeleteTemplate[Async]`, reimplemented `UpdateTemplate[Async]` to have proper parameters instead of an `object`. (Breaking change, not implementing backwards-compatible wrapper `UpdateTemplate(object)`.)
