### PR TITLE
Filter by label support on Template List

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ Asychronous:
    1. List
    2. Delete
  4. Templates
-   1. Render
-   2. Add
-   3. Update
-	 4. Info
+   1. List
+   2. Render
+   3. Add
+   4. Update
+	 5. Info
  5. Senders
    1. List
 	
@@ -78,7 +79,8 @@ set your own Api Key in the test project. Tests can be executed from rake: `rake
 tool.
 
 You will also need to create a test template in your Mandrill account. The template's html content must be set to '<span mc:edit="model1"></span>'.
-The template's name must match the TemplateExample setting in the AppSettings.config; 'Test' by default.
+The template's name must match the TemplateExample setting in the AppSettings.config; 'Test' by default. In addition, the template's label must
+match the TemplateLabel (default 'test').
 
 #### Contributors
 

--- a/src/Mandrill/IMandrillApi.cs
+++ b/src/Mandrill/IMandrillApi.cs
@@ -521,7 +521,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="List{T}" />.
         /// </returns>
-        List<TemplateInfo> ListTemplates();
+        List<TemplateInfo> ListTemplates(string label = "");
 
         /// <summary>
         ///     The list templates async.
@@ -529,7 +529,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="Task" />.
         /// </returns>
-        Task<List<TemplateInfo>> ListTemplatesAsync();
+        Task<List<TemplateInfo>> ListTemplatesAsync(string label = "");
 
         /// <summary>
         ///     The render.

--- a/src/Mandrill/Templates.cs
+++ b/src/Mandrill/Templates.cs
@@ -213,23 +213,29 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="List" />.
         /// </returns>
-        public List<TemplateInfo> ListTemplates()
+        public List<TemplateInfo> ListTemplates(string label = "")
         {
-            return this.ListTemplatesAsync().Result;
+            return this.ListTemplatesAsync(label).Result;
         }
 
         /// <summary>
         ///     The list templates async.
         /// </summary>
+        /// <param name="label">
+        ///     The optional label to filter the templates
+        /// </param>
         /// <returns>
         ///     The <see cref="Task" />.
         /// </returns>
-        public Task<List<TemplateInfo>> ListTemplatesAsync()
+        public Task<List<TemplateInfo>> ListTemplatesAsync(string label = "")
         {
             const string path = "/templates/list.json";
 
-            return this.PostAsync(path, null)
-                .ContinueWith(
+            dynamic payload = new ExpandoObject();
+            payload.label = label;
+
+            Task<IRestResponse> post = this.PostAsync(path, payload);
+            return post.ContinueWith(
                     p => JSON.Parse<List<TemplateInfo>>(p.Result.Content),
                     TaskContinuationOptions.ExecuteSynchronously);
         }

--- a/tests/AppSettings.example.config
+++ b/tests/AppSettings.example.config
@@ -7,6 +7,8 @@
   <add key="ValidToEmail" value="test@test.com" />
   <add key="FromEmail" value="test@test.com" />
   <add key="TemplateExample" value="Test" />
+  <add key="TemplateLabel" value="test" />
   <add key="TemplateCount" value="1" />
+  <add key="TemplateCountWithLabel" value="1" />
   <add key="UniqueExistingEmailSubject" value="Unique email subject to search"/>
 </appSettings>

--- a/tests/IntegrationTests/TemplatesTests.cs
+++ b/tests/IntegrationTests/TemplatesTests.cs
@@ -82,6 +82,24 @@ namespace Mandrill.Tests.IntegrationTests
         }
 
         [Test]
+        public void List_Templates_With_Label_Returns_Correct_Count()
+        {
+            // Setup
+            var apiKey = ConfigurationManager.AppSettings["APIKey"];
+            var templateCount = int.Parse(ConfigurationManager.AppSettings["TemplateCountWithLabel"]);
+            var label = ConfigurationManager.AppSettings["TemplateLabel"];            
+
+            // Exercise
+            var api = new MandrillApi(apiKey);
+            var result = api.ListTemplates(label);
+
+            var expected = templateCount;
+
+            // Verify
+            Assert.AreEqual(expected, result.Count);
+        }
+
+        [Test]
         public void Can_Update_Template()
         {
             // Setup


### PR DESCRIPTION
The filter by label support seems to be missing for the templates list, so I added it. I included unit test stuff too.

See: https://mandrillapp.com/api/docs/templates.JSON.html#method=list

VS2012 decided to normalise the line breaks, I'll resubmit if that's an issue.
