### PR TITLE
Renamed attachment to email_attachment to make it CLS compliant

### DIFF
--- a/src/Mandrill/Models/EmailMessage.cs
+++ b/src/Mandrill/Models/EmailMessage.cs
@@ -89,7 +89,7 @@ namespace Mandrill
     /// <summary>
     ///     The attachment.
     /// </summary>
-    public struct attachment
+    public struct email_attachment
     {
         #region Fields
 
@@ -146,7 +146,7 @@ namespace Mandrill
         /// <summary>
         ///     Gets or sets the attachments.
         /// </summary>
-        public IEnumerable<attachment> attachments { get; set; }
+        public IEnumerable<email_attachment> attachments { get; set; }
 
         /// <summary>
         ///     Gets or sets a value indicating whether auto_text.

--- a/src/Mandrill/Models/WebHookEvent.cs
+++ b/src/Mandrill/Models/WebHookEvent.cs
@@ -200,7 +200,7 @@ namespace Mandrill
         /// <summary>
         ///     Gets or sets the attachments.
         /// </summary>
-        public Dictionary<string, attachment> Attachments { get; set; }
+        public Dictionary<string, email_attachment> Attachments { get; set; }
 
         /// <summary>
         ///     Gets or sets the bounce description.


### PR DESCRIPTION
Fixes #73 / #75

I appreciate that this introduces a breaking change for existing C# users, but It would be good if attachments (which is core functionality) were available in VB.
