### PR TITLE
EMailMessage From Change

### DIFF
--- a/src/Mandrill/Models/EmailMessage.cs
+++ b/src/Mandrill/Models/EmailMessage.cs
@@ -286,6 +286,23 @@ namespace Mandrill
         public IEnumerable<EmailAddress> to { get; set; }
 
         /// <summary>
+        /// Gets or sets the from e-mail address as EmailAddress.
+        /// </summary>
+        public EmailAddress from 
+        {
+            get
+            {
+                return new EmailAddress { name = this.from_name, email = this.from_email, type = "from" };
+            }
+
+            set
+            {
+                this.from_name = value.name;
+                this.from_email = value.email;
+            }
+        }
+
+        /// <summary>
         ///     Gets or sets a value indicating whether track_clicks.
         /// </summary>
         public bool? track_clicks { get; set; }

--- a/src/Mandrill/Models/EmailMessage.cs
+++ b/src/Mandrill/Models/EmailMessage.cs
@@ -292,7 +292,7 @@ namespace Mandrill
         {
             get
             {
-                return new EmailAddress { name = this.from_name, email = this.from_email, type = "from" };
+                return new EmailAddress { name = this.from_name, email = this.from_email };
             }
 
             set


### PR DESCRIPTION
Hi,

I was just using the API and I wondered if there was a reason that to/cc/bcc are EMailAddress objects and the from settings aren't. 

I know there can be multiple of the former and only one from but it just seemed a little inconsistent.  Also, I think type should be an enum?

Thanks,

Dave
