### PR TITLE
Renamed useSsl-parameter to useHttps

### DIFF
--- a/src/Mandrill/MandrillApi.cs
+++ b/src/Mandrill/MandrillApi.cs
@@ -39,16 +39,16 @@ namespace Mandrill
         /// <param name="apiKey">
         ///     The API Key recieved from MandrillApp
         /// </param>
-        /// <param name="useSsl">
+        /// <param name="useHttps">
         /// </param>
         /// <param name="timeout">
         ///     Timeout in milliseconds to use for requests.
         /// </param>
-        public MandrillApi(string apiKey, bool useSsl = true, int timeout = 0)
+        public MandrillApi(string apiKey, bool useHttps = true, int timeout = 0)
         {
             this.ApiKey = apiKey;
 
-            if (useSsl)
+            if (useHttps)
             {
                 this.client = new RestClient(Configuration.BASE_SECURE_URL);
             }


### PR DESCRIPTION
The parameter name useSsl is confusing and misleading. Users have manually check if it actually enforce usage of ssl, which it don't. UseHttps is more correct.
