### PR TITLE
Fix send-raw-message

### DIFF
--- a/src/Mandrill/Messages.cs
+++ b/src/Mandrill/Messages.cs
@@ -492,7 +492,7 @@ namespace Mandrill
         }
 
         /// <summary>
-        ///     Send a new raw transactional message through Mandrill using a template
+        ///     Send a new raw message through Mandrill.
         /// </summary>
         /// <param name="message">
         ///     The message.
@@ -515,7 +515,7 @@ namespace Mandrill
                                   ? string.Empty
                                   : send_at.ToString(Configuration.DATE_TIME_FORMAT_STRING);
 
-            // payload.to = message.to;  // Does not work as advertised, silently fails with {"email":"Array","status":"invalid"}
+            payload.to = message.raw_to;
             Task<IRestResponse> post = this.PostAsync(path, payload);
             return post.ContinueWith(
                 p => { return JSON.Parse<List<EmailResult>>(p.Result.Content); },

--- a/src/Mandrill/Models/EmailMessage.cs
+++ b/src/Mandrill/Models/EmailMessage.cs
@@ -256,6 +256,11 @@ namespace Mandrill
         public string raw_message { get; set; }
 
         /// <summary>
+        ///     Gets or sets the string array to.
+        /// </summary>
+        public IEnumerable<string> raw_to { get; set; }
+
+        /// <summary>
         ///     Gets or sets the recipient_metadata.
         /// </summary>
         public IEnumerable<rcpt_metadata> recipient_metadata { get; set; }

--- a/tests/IntegrationTests/MessagesTests.cs
+++ b/tests/IntegrationTests/MessagesTests.cs
@@ -134,7 +134,8 @@ namespace Mandrill.Tests.IntegrationTests
                                                      new List<EmailAddress> { new EmailAddress { email = toEmail, name = "" } },
                                                  from_email = fromEmail,
                                                  from_name = "",
-                                                 raw_message = message
+                                                 raw_message = message,
+                                                 raw_to = new List<string> { toEmail }
                                              });
             // Verify
             Assert.AreEqual(1, result.Count);


### PR DESCRIPTION
The send-raw.json message call takes a raw MIME document for a message,
not a transactional message like send.json. This changes the "to"
parameter from an array of structs to simply an array of strings (_only_
the email address).