### PR TITLE
Added fix so that datetime could be nullified

### DIFF
--- a/src/Mandrill/IMandrillApi.cs
+++ b/src/Mandrill/IMandrillApi.cs
@@ -96,7 +96,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="ScheduledEmailResult" />.
         /// </returns>
-        ScheduledEmailResult RescheduleMessage(string id, DateTime send_at);
+        ScheduledEmailResult RescheduleMessage(string id, DateTime? send_at);
 
         /// <summary>
         ///     Send a new search instruction through Mandrill.
@@ -141,7 +141,7 @@ namespace Mandrill
             string subject,
             string content,
             EmailAddress from,
-            DateTime send_at = new DateTime());
+            DateTime? send_at);
 
         /// <summary>
         ///     Send a new transactional message through Mandrill using a template
@@ -168,7 +168,7 @@ namespace Mandrill
             EmailAddress from,
             string templateName,
             IEnumerable<TemplateContent> templateContents,
-            DateTime send_at = new DateTime());
+            DateTime? send_at);
 
         /// <summary>
         ///     The send message.
@@ -182,7 +182,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="List{T}" />.
         /// </returns>
-        List<EmailResult> SendMessage(EmailMessage message, DateTime send_at = new DateTime());
+        List<EmailResult> SendMessage(EmailMessage message, DateTime? send_at);
 
         /// <summary>
         ///     Send a new transactional message through Mandrill using a template
@@ -204,7 +204,7 @@ namespace Mandrill
             EmailMessage message,
             string templateName,
             IEnumerable<TemplateContent> templateContents,
-            DateTime send_at = new DateTime());
+            DateTime? send_at);
 
         /// <summary>
         ///     Send a new transactional message through Mandrill.
@@ -228,7 +228,7 @@ namespace Mandrill
             string subject,
             string content,
             EmailAddress from,
-            DateTime send_at = new DateTime());
+            DateTime? send_at);
 
         /// <summary>
         ///     Send a new transactional message through Mandrill using a template
@@ -255,7 +255,7 @@ namespace Mandrill
             EmailAddress from,
             string templateName,
             IEnumerable<TemplateContent> templateContents,
-            DateTime send_at = new DateTime());
+            DateTime? send_at);
 
         /// <summary>
         ///     Sends a new transactional message through Mandrill.
@@ -269,7 +269,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="Task" />.
         /// </returns>
-        Task<List<EmailResult>> SendMessageAsync(EmailMessage message, DateTime send_at = new DateTime());
+        Task<List<EmailResult>> SendMessageAsync(EmailMessage message, DateTime? send_at);
 
         /// <summary>
         ///     Send a new transactional message through Mandrill using a template
@@ -291,7 +291,7 @@ namespace Mandrill
             EmailMessage message,
             string templateName,
             IEnumerable<TemplateContent> templateContents,
-            DateTime send_at = new DateTime());
+            DateTime? send_at);
 
         /// <summary>
         ///     The send raw message.
@@ -305,7 +305,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="List{T}" />.
         /// </returns>
-        List<EmailResult> SendRawMessage(EmailMessage raw_message, DateTime send_at = new DateTime());
+        List<EmailResult> SendRawMessage(EmailMessage raw_message, DateTime? send_at);
 
         /// <summary>
         ///     Send a new raw transactional message through Mandrill using a template
@@ -319,7 +319,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="Task" />.
         /// </returns>
-        Task<List<EmailResult>> SendRawMessageAsync(EmailMessage message, DateTime send_at = new DateTime());
+        Task<List<EmailResult>> SendRawMessageAsync(EmailMessage message, DateTime? send_at);
 
         /// <summary>
         ///     The Api Key for the project received from the MandrillApp website

--- a/src/Mandrill/MandrillApi.cs
+++ b/src/Mandrill/MandrillApi.cs
@@ -27,7 +27,7 @@ namespace Mandrill
         /// <summary>
         ///     the main rest client for use throughout the whole app.
         /// </summary>
-        private readonly RestClient client;
+        private readonly RestClient _client;
 
         #endregion
 
@@ -50,15 +50,15 @@ namespace Mandrill
 
             if (useHttps)
             {
-                this.client = new RestClient(Configuration.BASE_SECURE_URL);
+                this._client = new RestClient(Configuration.BASE_SECURE_URL);
             }
             else
             {
-                this.client = new RestClient(Configuration.BASE_URL);
+                this._client = new RestClient(Configuration.BASE_URL);
             }
 
-            this.client.AddHandler("application/json", new DynamicJsonDeserializer());
-            this.client.Timeout = timeout;
+            this._client.AddHandler("application/json", new DynamicJsonDeserializer());
+            this._client.Timeout = timeout;
         }
 
         #endregion
@@ -74,11 +74,11 @@ namespace Mandrill
         {
             get
             {
-                return this.client.Proxy;
+                return this._client.Proxy;
             }
             set
             {
-                this.client.Proxy = value;
+                this._client.Proxy = value;
             }
         }
 
@@ -89,11 +89,11 @@ namespace Mandrill
         {
             get
             {
-                return this.client.UserAgent;
+                return this._client.UserAgent;
             }
             set
             {
-                this.client.UserAgent = value;
+                this._client.UserAgent = value;
             }
         }
 
@@ -126,7 +126,7 @@ namespace Mandrill
             data.key = ApiKey;
 
             request.AddBody(data);
-            client.ExecuteAsync(request, (response) =>
+            _client.ExecuteAsync(request, (response) =>
             {
                 // if internal server error, then mandrill should return a custom error.
                 if (response.StatusCode == HttpStatusCode.InternalServerError)

--- a/src/Mandrill/Messages.cs
+++ b/src/Mandrill/Messages.cs
@@ -175,15 +175,17 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="ScheduledEmailResult" />.
         /// </returns>
-        public ScheduledEmailResult RescheduleMessage(string id, DateTime send_at)
+        public ScheduledEmailResult RescheduleMessage(string id, DateTime? send_at)
         {
             string path = "/messages/reschedule.json";
 
             dynamic payload = new ExpandoObject();
             payload.id = id;
-            payload.send_at = (send_at == DateTime.MinValue)
-                                  ? string.Empty
-                                  : send_at.ToString(Configuration.DATE_TIME_FORMAT_STRING);
+
+            if(send_at != null)
+            {
+                payload.send_at = send_at.Value.ToString(Configuration.DATE_TIME_FORMAT_STRING);
+            }
 
             Task<IRestResponse> post = this.PostAsync(path, payload);
             return
@@ -250,12 +252,8 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="List" />.
         /// </returns>
-        public List<EmailResult> SendMessage(
-            IEnumerable<EmailAddress> recipients,
-            string subject,
-            string content,
-            EmailAddress from,
-            DateTime send_at = new DateTime())
+        public List<EmailResult> SendMessage(IEnumerable<EmailAddress> recipients, string subject,
+            string content, EmailAddress from, DateTime? send_at = null)
         {
             return SendMessageAsync(recipients, subject, content, from, send_at).Result;
         }
@@ -285,7 +283,7 @@ namespace Mandrill
             EmailAddress from,
             string templateName,
             IEnumerable<TemplateContent> templateContents,
-            DateTime send_at = new DateTime())
+            DateTime? send_at = null)
         {
             return this.SendMessageAsync(recipients, subject, from, templateName, templateContents, send_at).Result;
         }
@@ -302,7 +300,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="List" />.
         /// </returns>
-        public List<EmailResult> SendMessage(EmailMessage message, DateTime send_at = new DateTime())
+        public List<EmailResult> SendMessage(EmailMessage message, DateTime? send_at = null)
         {
             return this.SendMessageAsync(message, send_at).Result;
         }
@@ -327,7 +325,7 @@ namespace Mandrill
             EmailMessage message,
             string templateName,
             IEnumerable<TemplateContent> templateContents,
-            DateTime send_at = new DateTime())
+            DateTime? send_at = null)
         {
             return SendMessageAsync(message, templateName, templateContents, send_at).Result;
         }
@@ -349,12 +347,8 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="Task" />.
         /// </returns>
-        public Task<List<EmailResult>> SendMessageAsync(
-            IEnumerable<EmailAddress> recipients,
-            string subject,
-            string content,
-            EmailAddress from,
-            DateTime send_at = new DateTime())
+        public Task<List<EmailResult>> SendMessageAsync(IEnumerable<EmailAddress> recipients, string subject,
+            string content, EmailAddress from, DateTime? send_at = null)
         {
             var message = new EmailMessage
                               {
@@ -394,7 +388,7 @@ namespace Mandrill
             EmailAddress from,
             string templateName,
             IEnumerable<TemplateContent> templateContents,
-            DateTime send_at = new DateTime())
+            DateTime? send_at = null)
         {
             var message = new EmailMessage
                               {
@@ -419,15 +413,17 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="Task" />.
         /// </returns>
-        public Task<List<EmailResult>> SendMessageAsync(EmailMessage message, DateTime send_at = new DateTime())
+        public Task<List<EmailResult>> SendMessageAsync(EmailMessage message, DateTime? send_at = null)
         {
             string path = "/messages/send.json";
 
             dynamic payload = new ExpandoObject();
             payload.message = message;
-            payload.send_at = (send_at == DateTime.MinValue)
-                                  ? string.Empty
-                                  : send_at.ToString(Configuration.DATE_TIME_FORMAT_STRING);
+            if (send_at != null)
+            {
+                payload.send_at = send_at.Value.ToString(Configuration.DATE_TIME_FORMAT_STRING);
+            }
+            
 
             Task<IRestResponse> post = this.PostAsync(path, payload);
 
@@ -456,7 +452,7 @@ namespace Mandrill
             EmailMessage message,
             string templateName,
             IEnumerable<TemplateContent> templateContents,
-            DateTime send_at = new DateTime())
+            DateTime? send_at = null)
         {
             string path = "/messages/send-template.json";
 
@@ -464,9 +460,10 @@ namespace Mandrill
             payload.message = message;
             payload.template_name = templateName;
             payload.template_content = templateContents != null ? templateContents : Enumerable.Empty<TemplateContent>();
-            payload.send_at = (send_at == DateTime.MinValue)
-                                  ? string.Empty
-                                  : send_at.ToString(Configuration.DATE_TIME_FORMAT_STRING);
+            if (send_at != null)
+            {
+                payload.send_at = send_at.Value.ToString(Configuration.DATE_TIME_FORMAT_STRING);
+            }
 
             Task<IRestResponse> post = this.PostAsync(path, payload);
             return post.ContinueWith(
@@ -486,7 +483,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="List" />.
         /// </returns>
-        public List<EmailResult> SendRawMessage(EmailMessage raw_message, DateTime send_at = new DateTime())
+        public List<EmailResult> SendRawMessage(EmailMessage raw_message, DateTime? send_at = null)
         {
             return this.SendRawMessageAsync(raw_message, send_at).Result;
         }
@@ -503,7 +500,7 @@ namespace Mandrill
         /// <returns>
         ///     The <see cref="Task" />.
         /// </returns>
-        public Task<List<EmailResult>> SendRawMessageAsync(EmailMessage message, DateTime send_at = new DateTime())
+        public Task<List<EmailResult>> SendRawMessageAsync(EmailMessage message, DateTime? send_at = null)
         {
             string path = "/messages/send-raw.json";
 
@@ -511,9 +508,10 @@ namespace Mandrill
             payload.raw_message = message.raw_message;
             payload.from_email = message.from_email;
             payload.from_name = message.from_name;
-            payload.send_at = (send_at == DateTime.MinValue)
-                                  ? string.Empty
-                                  : send_at.ToString(Configuration.DATE_TIME_FORMAT_STRING);
+            if (send_at != null)
+            {
+                payload.send_at = send_at.Value.ToString(Configuration.DATE_TIME_FORMAT_STRING);
+            }
 
             // payload.to = message.to;  // Does not work as advertised, silently fails with {"email":"Array","status":"invalid"}
             Task<IRestResponse> post = this.PostAsync(path, payload);

--- a/tests/IntegrationTests/MessagesTests.cs
+++ b/tests/IntegrationTests/MessagesTests.cs
@@ -15,7 +15,7 @@ namespace Mandrill.Tests.IntegrationTests
     [TestFixture]
     public class MessagesTests
     {
-        private bool isPaidAccount;
+        private bool _isPaidAccount;
         public static bool Validator (object sender, X509Certificate certificate, X509Chain chain, 
                                       SslPolicyErrors sslPolicyErrors) {
             return true;
@@ -26,7 +26,7 @@ namespace Mandrill.Tests.IntegrationTests
             if (ConfigurationManager.AppSettings["IgnoreInvalidSSLCertificate"] == "True")
                 ServicePointManager.ServerCertificateValidationCallback = Validator;
 
-            isPaidAccount = ConfigurationManager.AppSettings["IsPaidAccount"] == "True";
+            _isPaidAccount = ConfigurationManager.AppSettings["IsPaidAccount"] == "True";
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace Mandrill.Tests.IntegrationTests
         [Test]
         public void Message_With_Send_At_Is_Scheduled_For_Paid_Account()
         {
-            if(!isPaidAccount)
+            if(!_isPaidAccount)
                 Assert.Ignore("Not a paid account");
 
             // Setup
@@ -179,7 +179,7 @@ namespace Mandrill.Tests.IntegrationTests
         [Test]
         public void Scheduled_Message_Is_Rescheduled_For_Paid_Account()
         {
-            if (!isPaidAccount)
+            if (!_isPaidAccount)
                 Assert.Ignore("Not a paid account");
             // Setup
             var apiKey = ConfigurationManager.AppSettings["APIKey"];
@@ -213,7 +213,7 @@ namespace Mandrill.Tests.IntegrationTests
         [Test]
         public void Scheduled_Message_Is_Canceled_For_Paid_Account()
         {
-            if (!isPaidAccount)
+            if (!_isPaidAccount)
                 Assert.Ignore("Not a paid account");
             // Setup
             var apiKey = ConfigurationManager.AppSettings["APIKey"];


### PR DESCRIPTION
Hiya,

I have fixed date time so that it's nullable; by default you set datetime if no send_at is specified, which is interpreted by Mandrill as you asking for a scheduled send; a feature of paid accounts only, resulting in Mandrill-dotnet not working for free accounts.

Cheers,

Nick