### PR TITLE
Default preserve_recipients to false instead of null

### DIFF
--- a/src/Mandrill/Models/EmailMessage.cs
+++ b/src/Mandrill/Models/EmailMessage.cs
@@ -246,9 +246,9 @@ namespace Mandrill
         public JsonObject metadata { get; private set; }
 
         /// <summary>
-        ///     Gets or sets a value indicating whether preserve_recipients.
+        ///     Gets or sets whether or not to expose all recipients in to "To" header for each email.
         /// </summary>
-        public bool? preserve_recipients { get; set; }
+        public bool preserve_recipients { get; set; }
 
         /// <summary>
         ///     Gets or sets the raw_message.


### PR DESCRIPTION
The change to convert boolean fields in `EmailMessage` into nullable fields from #84 and #85 has caused a side effect with the `preserve_recipients` field. The previous behavior was to default this field to `false` whereas after the change it defaults to `null` which effectively causes Mandrill to interpret this as not specifying a value at all. Not specifying a value is not the same as setting it to `false` however.

From Mandrill Support:

>We can definitely see how this would be extremely confusing and agree that it is most logical that null would be equal to a false value instead of a truthy one. What happened on this case, is that having a null value in the API makes it as if this value would have been omitted completely, so it would be equivalent to just not including `preserve_recipients: null` at all.
>
>When this value is not included in the API call, Mandrill then falls back on the default value for this option. This default value is set in the [Sending Defaults](https://mandrillapp.com/settings/sending-options) page of your account, with the checkbox that reads **Expose The List Of Recipients When Sending To Multiple Addresses**. When that box is checked, it makes the default for that value `true` and leaving it null in the API will make it `true` for that same reason.
>
>By unchecking that box, you could then leave the `preservere_recipients` parameter as `null`, `false`, or just not include it at all, and it will default to `false` every time, except if you would explicitly set it to `true`.

I'm not sure if this an undocumented feature but I didn't discover it until upgrading the library from 1.0.85 to 1.2.1 and learning through customer complaints that the "To" line was showing other addresses. I can sympathize with them, it looked like their email with sensitive information was being sent to multiple people.

I propose changing the `preserve_recipients` field back to a boolean data type so it defaults to `false` unless otherwise set. I wouldn't be surprised if others using this library have experienced the same result and didn't even know it since Mandrill's web site doesn't show you the headers that the customer received.