### PR TITLE
Fix typo in the JsonProperty name

### DIFF
--- a/src/Mandrill/Models/EmailAddress.cs
+++ b/src/Mandrill/Models/EmailAddress.cs
@@ -91,7 +91,7 @@ namespace Mandrill.Models
     ///   The header type to use for the recipient, defaults to "to" if not provided
     ///   oneof(to, cc, bcc)
     /// </summary>
-    [JsonProperty("tyoe")]
+    [JsonProperty("type")]
     public string Type { get; set; }
 
     #endregion


### PR DESCRIPTION
I guess this was a typo in the name of the json property.