### PR TITLE
Adapted MergeVar to support both string and array content (new handlebars syntax)

### DIFF
--- a/src/Mandrill/Models/EmailMessage.cs
+++ b/src/Mandrill/Models/EmailMessage.cs
@@ -41,7 +41,7 @@ namespace Mandrill.Models
     ///   The content.
     /// </summary>
     [JsonProperty("content")]
-    public string Content { get; set; }
+      public dynamic Content { get; set; }
 
     /// <summary>
     ///   The name.
@@ -468,7 +468,7 @@ namespace Mandrill.Models
     /// <param name="content">
     ///   The content.
     /// </param>
-    public void AddRecipientVariable(string recipient, string name, string content)
+    public void AddRecipientVariable(string recipient, string name, dynamic content)
     {
       if (MergeVars == null)
       {
@@ -486,7 +486,6 @@ namespace Mandrill.Models
 
       entry.Vars.Add(mv);
     }
-
     #endregion
   }
 }


### PR DESCRIPTION
Added support for new [handlebar syntax](https://mandrill.zendesk.com/hc/en-us/articles/205582537-Using-Handlebars-for-dynamic-content) by allowing a MergeVar's content attribute to work with both strings and arrays. 

All credits go to http://stackoverflow.com/a/29401083/414376 .

