### PR TITLE
Adding Headers field to WebHookMessage

### DIFF
--- a/src/Mandrill/Models/WebHookEvent.cs
+++ b/src/Mandrill/Models/WebHookEvent.cs
@@ -240,6 +240,11 @@ namespace Mandrill.Models
     [JsonProperty("from_name")]
     public string FromName { get; set; }
 
+	/// <summary>
+	/// Gets or sets the headers.
+	/// </summary>
+	public Dictionary<string, dynamic> Headers { get; set; }
+
     /// <summary>
     ///   Gets or sets the html.
     /// </summary>


### PR DESCRIPTION
Inbound webhook messages contain a JSON field for headers that is not currently being deserialized.  It often looks something like this:

```
[{
    ""event"": ""inbound"",
    ""msg"": {
      ""ts"": 1365109999,
      ""headers"": {""Received"":[""from ip-smtp-bulk2.somedomain.com (unknown [111.222.33.44]) by ip-11-22-33-99 (Postfix) with ESMTP id EA4F1411113 for <test@test.com>; Mon, 15 Jun 2015 11:25:59 +0000 (UTC)"",""from unknown (HELO WEBSKADV3) ([11.22.22.33]) by ip-smtp-web2.somedomain.com with ESMTP; 15 Jun 2015 21:25:58 +1000""], ""Message-Id"":""<asdf3$oip3@ip-smtp-web2.somedomain.com>"",""Mime-Version"":""1.0"",""From"":""'Some Person' <noreply@somedomain.com>"",""To"":""'Another Person' <test@test.com>"",""Reply-To"":""'Some Person' <my-reply-to-address@somedomain.com>"",""Date"":""15 Jun 2015 21:25:58 +1000"",""Subject"":""Important Stuff"",""Content-Type"":""multipart\/mixed; boundary=--boundary_14460_7f7a0f53-b4b3-495c-a76b-b26e16eddbac""},
      ""subject"": ""This an example webhook message"",
      ""email"": ""example.webhook@mandrillapp.com"",
      ""sender"": ""example.sender@mandrillapp.com"",
      ""tags"": [
        ""webhook-example""
      ],
      ""metadata"": {
        ""user_id"": 111
      }
    }
  }]
```

As far as I can tell, this is the only place the Reply-To field is available, which can be very important for processing inbound messages.  Most of the field seems to be a string/string dictionary, but it often is prepended with a string/array entry.  This change adds a string/dynamic dictionary field to ensure proper deserialization of whatever is in there.