### PR TITLE
Create MergeLanguage.cs

### DIFF
--- a/src/Mandrill/Models/MergeLanguage.cs
+++ b/src/Mandrill/Models/MergeLanguage.cs
@@ -1,0 +1,8 @@
+namespace Mandrill.Models
+{
+    public static class MergeLanguage
+    {
+        public const string Handlebars = "handlebars";
+        public const string MailChimp = "mailchimp";
+    }
+}


### PR DESCRIPTION
Adds a static class with some string constants for setting the MergeLanguage when sending a message. This should help developers when choosing a merge language without requiring them to consult the Mandrill api docs.

An enum would arguably be better, but I didn't want to break your API and I didn't know if there was a good reason for having a string (like custom merge languages or something like that).