### PR TITLE
Change configuration static class to Public to allow customization

### DIFF
--- a/src/Mandrill/Configuration.cs
+++ b/src/Mandrill/Configuration.cs
@@ -7,12 +7,13 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System.Configuration;
 namespace Mandrill
 {
   /// <summary>
   ///   The configuration.
   /// </summary>
-  internal static class Configuration
+  public static class Configuration
   {
     #region Static Fields
 


### PR DESCRIPTION
Change configuration static class to Public to allow customization of onfig values (e.g. Changing URL)
Can be used to change the API url to use the static URL of Mandrill, which is required in case it is being used behind a firewall.