### PR TITLE
Allow the sending of templates without template content.

### DIFF
--- a/src/Mandrill/Requests/Messages/SendMessageTemplateRequest.cs
+++ b/src/Mandrill/Requests/Messages/SendMessageTemplateRequest.cs
@@ -15,6 +15,18 @@ namespace Mandrill.Requests.Messages
     /// </summary>
     /// <param name="message">The other information on the message to send - same as /messages/send, but without the html content.</param>
     /// <param name="templateName">The immutable name or slug of a template that exists in the user's account. For backwards-compatibility, the template name may also be used but the immutable slug is preferred.</param>
+    public SendMessageTemplateRequest(EmailMessage message, string templateName)
+    {
+      Message = message;
+      TemplateName = templateName;
+      TemplateContents = new TemplateContent[] {};
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="message">The other information on the message to send - same as /messages/send, but without the html content.</param>
+    /// <param name="templateName">The immutable name or slug of a template that exists in the user's account. For backwards-compatibility, the template name may also be used but the immutable slug is preferred.</param>
     /// <param name="templateContents">An array of template content to send.</param>
     public SendMessageTemplateRequest(EmailMessage message, string templateName, IEnumerable<TemplateContent> templateContents)
     {

--- a/tests/IntegrationTests/Messages/SendTemplateTests.cs
+++ b/tests/IntegrationTests/Messages/SendTemplateTests.cs
@@ -81,5 +81,33 @@ namespace Mandrill.Tests.IntegrationTests.Messages
       Assert.AreEqual(toEmail, result.First().Email);
       Assert.AreEqual(EmailResultStatus.Sent, result.First().Status);
     }
+
+    [Test]
+    public async Task Should_Not_Require_Template_Content()
+    {
+      // Setup
+      string apiKey = ConfigurationManager.AppSettings["APIKey"];
+      string toEmail = ConfigurationManager.AppSettings["ValidToEmail"];
+      string fromEmail = ConfigurationManager.AppSettings["FromEMail"];
+      string templateExample = ConfigurationManager.AppSettings["TemplateExample"];
+
+      // Exercise
+      var api = new MandrillApi(apiKey);
+
+      List<EmailResult> result = await api.SendMessageTemplate(new SendMessageTemplateRequest
+      (new EmailMessage
+        {
+          To =
+            new List<EmailAddress> {new EmailAddress {Email = toEmail, Name = ""}},
+          FromEmail = fromEmail,
+          Subject = "Mandrill Integration Test",
+        },
+        templateExample));
+
+      // Verify
+      Assert.AreEqual(1, result.Count);
+      Assert.AreEqual(toEmail, result.First().Email);
+      Assert.AreEqual(EmailResultStatus.Sent, result.First().Status);
+    }
   }
 }


### PR DESCRIPTION
I've sent lots of emails through Mandril, but this is the first time I've done it with C#.  I was a little confused on the idea of a "template content," which I had never used.  I thought they might be merge variables?  I eventually figured it out, learning the difference between template content and merge variables.

I understand why ``TemplateContent`` is a required argument -- it's required for the API.  But like I saw in this SO post from a Mandrill rep, an array of template content is required for backwards compatibility because they were around before merge variables existed.

Given that, and my general confusion, and the fact that sending template emails probably requires many people to awkwardly create an empty array as an argument, I recommend having a second constructor with no array -- setting the TemplateContent to an empty array for you.

![screenshot_021116_064913_am](https://cloud.githubusercontent.com/assets/148768/12976682/90db6fc2-d08b-11e5-908f-f807110d398a.jpg)