### PR TITLE
Support for static endpoint

### DIFF
--- a/src/Mandrill/Configuration.cs
+++ b/src/Mandrill/Configuration.cs
@@ -27,6 +27,16 @@ namespace Mandrill
     public static string BASE_URL = "http://mandrillapp.com/api/1.0/";
 
     /// <summary>
+    ///   The bas e_ secur e_ url.
+    /// </summary>
+    public static string BASE_STATIC_SECURE_URL = "https://static.mandrillapp.com/api/1.0/";
+
+    /// <summary>
+    ///   The bas e_ url.
+    /// </summary>
+    public static string BASE_STATIC_URL = "http://static.mandrillapp.com/api/1.0/";
+
+    /// <summary>
     ///   The dat e_ tim e_ forma t_ string.
     /// </summary>
     public static string DATE_TIME_FORMAT_STRING = "yyyy-MM-dd HH:mm:ss";

--- a/src/Mandrill/MandrillApi.cs
+++ b/src/Mandrill/MandrillApi.cs
@@ -47,14 +47,25 @@ namespace Mandrill
     {
       ApiKey = apiKey;
 
-      if (useHttps)
+      if (useHttps && useStatic)
+      {
+        baseUrl = Configuration.BASE_STATIC_SECURE_URL;
+      }
+      else if (useHttps && !useStatic)
       {
         baseUrl = Configuration.BASE_SECURE_URL;
+      }
+      else if (!useHttps && useStatic)
+      {
+        baseUrl = Configuration.BASE_STATIC_URL;
       }
       else
       {
         baseUrl = Configuration.BASE_URL;
       }
+      
+      // Store URL value to be used in public BaseURL property
+      BaseUrl = baseUrl;
     }
 
     #endregion
@@ -66,6 +77,11 @@ namespace Mandrill
     /// </summary>
     public string ApiKey { get; private set; }
 
+    ///<Summary>
+    /// The base URL value being used for call, useful for client logging purposes
+    ///</Summary>
+    public string BaseUrl { get; set; }
+    
     #endregion
 
     #region Public Methods and Operators

--- a/src/Mandrill/MandrillApi.cs
+++ b/src/Mandrill/MandrillApi.cs
@@ -40,10 +40,9 @@ namespace Mandrill
     /// </param>
     /// <param name="useHttps">
     /// </param>
-    /// <param name="timeout">
-    ///   Timeout in milliseconds to use for requests.
+    /// <param name="useStatic">
     /// </param>
-    public MandrillApi(string apiKey, bool useHttps = true)
+    public MandrillApi(string apiKey, bool useHttps = true, bool useStatic = false)
     {
       ApiKey = apiKey;
 


### PR DESCRIPTION
In addition to the regular endpoint for their relay servers, Mandrill also supports a 'static' endpoint. Send requests via the static endpoint are a bit slower, but its IP addresses don't change as often (although they do still change). Using the static endpoint can be preferable if one's firewall is having trouble keeping up with the more frequently changing IPs on the regular endpoint.

I've added support for this static Mandrill endpoint by adding its API URL in the configuration class, and wired it up for use in the MandrillApi class via an optional parameter (useStatic, which works in tandem with the existing useHttps parameter). I've also added a public BaseUrl property that exposes which endpoint URL is being used, so it can be accessed by the client. These changes have been successfully tested locally.

Cheers.
