### PR TITLE
Fix WebHookEvent.Msg.Metadata serialization always resulting in null 

### DIFF
--- a/src/Mandrill/Models/WebHookEvent.cs
+++ b/src/Mandrill/Models/WebHookEvent.cs
@@ -435,7 +435,7 @@ namespace Mandrill.Models
         if (value == null) return;
 
         //generate JSON for WebHookMetadata
-        var webHookMetadata = value as WebHookMetadata;
+        var webHookMetadata = value as List<WebHookMetadata>;
 
         if (webHookMetadata == null)
         {
@@ -445,12 +445,12 @@ namespace Mandrill.Models
 
         writer.WriteStartObject();
 
-        writer.WritePropertyName("Key");
-        serializer.Serialize(writer, webHookMetadata.Key);
-
-        writer.WritePropertyName("Value");
-        serializer.Serialize(writer, webHookMetadata.Value);
-
+        foreach (var metadata in webHookMetadata)
+        {
+          writer.WritePropertyName(metadata.Key);
+          serializer.Serialize(writer, metadata.Value);  
+        }
+        
         writer.WriteEndObject();
       }
 

--- a/tests/IntegrationTests/WebHookTests.cs
+++ b/tests/IntegrationTests/WebHookTests.cs
@@ -126,5 +126,49 @@ namespace Mandrill.Tests.IntegrationTests
       Assert.AreEqual(1, events.Count);
       Assert.AreEqual(WebHookMessageState.Soft_bounced, events[0].Msg.State);
     }
+
+    [Test]
+    public void Event_Serialize()
+    {
+      var webhook = 
+        new WebHookEvent
+        {
+          Event = WebHookEventType.Click,
+          IP = "127.0.0.1",
+          TS = 1355340679,
+          Url = "http://clicked.me",
+          UserAgent = "outlook",
+          Msg = new WebHookMessage
+          {
+            TS = 1355340679,
+            Subject = "Important Stuff",
+            Email = "ValidToOne@Valid.com",
+            Tags = new List<string> { "tag1", "tag2", "tag3" },
+            Metadata = new List<WebHookMetadata>
+            {
+              new WebHookMetadata { Key = "key1", Value = "val1" },
+              new WebHookMetadata { Key = "key2", Value = "val2" }
+            },
+            Opens = new List<WebHookOpen>
+            {
+                new WebHookOpen { TS = 1355340679 },
+                new WebHookOpen { TS = 1355340679 }
+            },
+            State = WebHookMessageState.Sent,
+            Clicks = new List<WebHookClick>
+            {
+                new WebHookClick { TS = 1355773922, Url = @"http:\\www.GitHub.com"}
+            },
+            Id = "fc8071b3575e44228d5dd7059349ba10",
+            Sender = "ValidFrom@From.com",
+            Template = "ValidTemplate",
+            SubAccount = "validSubAccount"
+          }
+        };
+
+      var output = JSON.Serialize(webhook);
+      var clone = JSON.Parse<WebHookEvent>(output);
+      Assert.That(webhook.Msg.Metadata.Count == clone.Msg.Metadata.Count);
+    }
   }
 }


### PR DESCRIPTION
Found an issue where MetadataConverter.WriteJson was always writing null due to a casting issue.