### PR TITLE
Skip DOTNET CLI setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 image: Visual Studio 2017
 platform: Any CPU
 configuration: Release
+environment:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
 before_build:
   - dotnet restore
 build:


### PR DESCRIPTION
This will speed up builds and prevent a lot of noise from being dumped into the AV logs.