### PR TITLE
Change target framework to netstandard1.1

### DIFF
--- a/Mandrill.sln
+++ b/Mandrill.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.14
+VisualStudioVersion = 15.0.26711.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{ACA85DEE-F68F-45DD-9435-14755FFBFDC9}"
 EndProject
@@ -10,7 +10,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{45609E63-CCF9-4A89-BAFE-0BE96C303BF4}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
-		global.json = global.json
 		LICENSE.txt = LICENSE.txt
 		README.md = README.md
 		UpdateVersion.ps1 = UpdateVersion.ps1
@@ -23,7 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{67E7
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mandrill", "src\Mandrill\Mandrill.csproj", "{F906713E-71C4-41A9-9F4B-EE1EB9F33AEF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mandrill.Tests", "tests\Mandrill.Tests\Mandrill.Tests.csproj", "{FAEAD1E5-40DE-4A7B-8ADB-2ACE6384F92D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mandrill.Tests", "tests\Mandrill.Tests\Mandrill.Tests.csproj", "{FAEAD1E5-40DE-4A7B-8ADB-2ACE6384F92D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -46,5 +45,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F906713E-71C4-41A9-9F4B-EE1EB9F33AEF} = {ACA85DEE-F68F-45DD-9435-14755FFBFDC9}
 		{FAEAD1E5-40DE-4A7B-8ADB-2ACE6384F92D} = {EF2B1A8B-ED3A-45DB-AA2D-432CB44049B0}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {687A6EAF-62AE-4A48-ABB1-0ADAC11600A3}
 	EndGlobalSection
 EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,3 +1,0 @@
-{
-  "projects": [ "src", "tests" ]
-}

--- a/src/Mandrill/Mandrill.csproj
+++ b/src/Mandrill/Mandrill.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Shawn Mclean</Authors>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>


### PR DESCRIPTION
This will allow us to run on the below frameworks:

![image](https://user-images.githubusercontent.com/515955/28443540-11542326-6dfa-11e7-862c-8c66d54bf0e5.png)


I've also removed some more legacy bits like `global.json` which is no longer required.