### PR TITLE
Fixes #193 Removes using statement around _httpClient

### DIFF
--- a/src/Mandrill/MandrillApi.cs
+++ b/src/Mandrill/MandrillApi.cs
@@ -22,7 +22,7 @@ namespace Mandrill
   /// <summary>
   ///   Core class for using the MandrillApp Api
   /// </summary>
-  public partial class MandrillApi
+  public partial class MandrillApi : IDisposable
   {
     #region Constructors and Destructors
 
@@ -175,6 +175,11 @@ namespace Mandrill
       }
     }
 
-    #endregion
+    public void Dispose()
+    {
+        ((IDisposable)_httpClient).Dispose();
+    }
+
+        #endregion
   }
 }

--- a/src/Mandrill/MandrillApi.cs
+++ b/src/Mandrill/MandrillApi.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MandrillApi.cs" company="">
-//   
+//
 // </copyright>
 // <summary>
 //   Core class for using the MandrillApp Api
@@ -52,7 +52,10 @@ namespace Mandrill
       // Store URL value to be used in public BaseURL property
       BaseUrl = baseUrl;
 
-      _httpClient = new HttpClient();
+      _httpClient = new HttpClient
+      {
+          BaseAddress = new Uri(BaseUrl)
+      };
     }
 
     #endregion
@@ -118,7 +121,7 @@ namespace Mandrill
     /// <Summary>
     ///   The base URL value being used for call, useful for client logging purposes
     /// </Summary>
-    public string BaseUrl { get; set; }
+    public string BaseUrl { get; }
 
     #endregion
 
@@ -144,9 +147,6 @@ namespace Mandrill
       data.Key = ApiKey;
       try
       {
-        using (var client = _httpClient)
-        {
-          client.BaseAddress = new Uri(baseUrl);
 
           string requestContent;
           try
@@ -160,7 +160,7 @@ namespace Mandrill
 
           var response =
             await
-              client.PostAsync(
+              _httpClient.PostAsync(
                   path,
                   new StringContent(requestContent, Encoding.UTF8, "application/json"))
                 .ConfigureAwait(false);
@@ -169,7 +169,6 @@ namespace Mandrill
 
           return ParseResponseContent<T>(path, data, responseContent, response);
         }
-      }
       catch (TimeoutException ex)
       {
         throw new TimeoutException(string.Format("Post timed out to {0}", path), ex);

--- a/tests/Mandrill.Tests/UnitTests/PostTests.cs
+++ b/tests/Mandrill.Tests/UnitTests/PostTests.cs
@@ -28,7 +28,11 @@ namespace Mandrill.Tests.UnitTests
       var responseMessage = new HttpResponseMessage(statusCode);
       responseMessage.Content = new FakeHttpContent(content);
       var messageHandler = new FakeHttpMessageHandler(responseMessage);
-      api.SetHttpClient(new HttpClient(messageHandler));
+      var httpClient = new HttpClient(messageHandler)
+      {
+          BaseAddress = new Uri(Configuration.BASE_SECURE_URL)
+      };
+      api.SetHttpClient(httpClient);
     }
 
     private HttpClient httpClient;
@@ -89,7 +93,7 @@ namespace Mandrill.Tests.UnitTests
         var api = new MandrillApi("");
         RespondWith(api, HttpStatusCode.OK, responseString);
         await api.Post<SampleObject>("", new SamplePayload());
-
+        await api.Post<SampleObject>("", new SamplePayload());
     }
 
     [Fact]

--- a/tests/Mandrill.Tests/UnitTests/PostTests.cs
+++ b/tests/Mandrill.Tests/UnitTests/PostTests.cs
@@ -11,143 +11,138 @@ using Xunit;
 
 namespace Mandrill.Tests.UnitTests
 {
-    public class PostTests : IDisposable
+  public class PostTests : IDisposable
+  {
+    public PostTests()
     {
-        public PostTests()
-        {
-            var responseMessage = new HttpResponseMessage();
-            var messageHandler = new FakeHttpMessageHandler(responseMessage);
-            httpClient = new HttpClient(messageHandler);
-        }
-        public void Dispose()
-        {
-            httpClient?.Dispose();
-        }
+      var responseMessage = new HttpResponseMessage();
+      var messageHandler = new FakeHttpMessageHandler(responseMessage);
+      httpClient = new HttpClient(messageHandler);
+    }
+    public void Dispose() {
+      httpClient?.Dispose();
+    }
 
-        private void RespondWith(MandrillApi api, HttpStatusCode statusCode, string content)
-        {
-            var responseMessage = new HttpResponseMessage(statusCode);
-            responseMessage.Content = new FakeHttpContent(content);
-            var messageHandler = new FakeHttpMessageHandler(responseMessage);
-            api.SetHttpClient(new HttpClient(messageHandler));
-        }
+    private void RespondWith(MandrillApi api, HttpStatusCode statusCode, string content)
+    {
+      var responseMessage = new HttpResponseMessage(statusCode);
+      responseMessage.Content = new FakeHttpContent(content);
+      var messageHandler = new FakeHttpMessageHandler(responseMessage);
+      api.SetHttpClient(new HttpClient(messageHandler));
+    }
 
-        private HttpClient httpClient;
+    private HttpClient httpClient;
 
-        private class SampleObject
-        {
-            public string Name { get; set; }
-            public int Id { get; set; }
-        }
+    private class SampleObject
+    {
+      public string Name { get; set; }
+      public int Id { get; set; }
+    }
 
-        private class SamplePayload : RequestBase
-        {
-        }
+    private class SamplePayload : RequestBase
+    {
+    }
 
-        [Fact]
-        public async Task Should_Serialize_Response_When_Json_Content_Is_Recieved()
-        {
-            string responseString = @"{
+    [Fact]
+    public async Task Should_Serialize_Response_When_Json_Content_Is_Recieved()
+    {
+      string responseString = @"{
 	      ""Name"": ""Shawn"",
 	      ""Id"": 1
       }";
-            var api = new MandrillApi("");
-            RespondWith(api, HttpStatusCode.OK, responseString);
+      var api = new MandrillApi("");
+      RespondWith(api, HttpStatusCode.OK, responseString);
 
-            SampleObject response = await api.Post<SampleObject>("", new SamplePayload());
+      SampleObject response = await api.Post<SampleObject>("", new SamplePayload());
 
-            Assert.Equal("Shawn", response.Name);
-            Assert.Equal(1, response.Id);
-        }
+      Assert.Equal("Shawn", response.Name);
+      Assert.Equal(1, response.Id);
+    }
 
-        [Fact]
-        public async Task Should_Throw_Mandrill_Exception_When_Server_Error()
-        {
-            string responseString = @"{
-	          ""code"": ""501"",
-	          ""message"": ""m1"",
-	          ""name"": ""n1"",
-	          ""status"": ""s1""
-            }";
+    [Fact]
+    public async Task Should_Throw_Mandrill_Exception_When_Server_Error()
+    {
+      string responseString = @"{
+	      ""code"": ""501"",
+	      ""message"": ""m1"",
+	      ""name"": ""n1"",
+	      ""status"": ""s1""
+      }";
 
-            var api = new MandrillApi("");
-            RespondWith(api, HttpStatusCode.InternalServerError, responseString);
+      var api = new MandrillApi("");
+      RespondWith(api, HttpStatusCode.InternalServerError, responseString);
 
-            var ex = await Assert.ThrowsAsync<MandrillException>(async () => await api.Post<object>("", new SamplePayload()));
-            Assert.Equal(501, ex.Error.Code);
-            Assert.Equal("m1", ex.Error.Message);
-            Assert.Equal("n1", ex.Error.Name);
-            Assert.Equal("s1", ex.Error.Status);
-        }
+      var ex = await Assert.ThrowsAsync<MandrillException>(async () => await api.Post<object>("", new SamplePayload()));
+      Assert.Equal(501, ex.Error.Code);
+      Assert.Equal("m1", ex.Error.Message);
+      Assert.Equal("n1", ex.Error.Name);
+      Assert.Equal("s1", ex.Error.Status);
+    }
 
-        [Fact]
-        public async Task Should_Allow_Multiple_Requests_With_Single_HttpClient()
-        {
-            string responseString = @"{
-	            ""Name"": ""Shawn"",
-	            ""Id"": 1
-            }";
-            var api = new MandrillApi("");
-
-            RespondWith(api, HttpStatusCode.OK, responseString);
-
-            await api.Post<SampleObject>("", new SamplePayload());
-
-            await api.Post<SampleObject>("", new SamplePayload());
-
-        }
-
-        [Fact]
-        public async Task Should_Throw_Mandrill_Exception_When_Serialization_Error()
-        {
-            string responseString = @"<html></html>";
-
-            var api = new MandrillApi("");
-            RespondWith(api, HttpStatusCode.OK, responseString);
-
-            var ex = await Assert.ThrowsAsync<MandrillSerializationException>(async () => await api.Post<object>("", new SamplePayload()));
-            var content = await ex.HttpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
-            Assert.Equal(responseString, content);
-        }
-        public class FakeHttpMessageHandler : HttpMessageHandler
-        {
-            private HttpResponseMessage response;
-
-            public FakeHttpMessageHandler(HttpResponseMessage response)
-            {
-                this.response = response;
-            }
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                var responseTask = new TaskCompletionSource<HttpResponseMessage>();
-                responseTask.SetResult(response);
-
-                return responseTask.Task;
-            }
-        }
-
-        public class FakeHttpContent : HttpContent
-        {
-            public string Content { get; set; }
-
-            public FakeHttpContent(string content)
-            {
-                Content = content;
-            }
-
-            protected async override Task SerializeToStreamAsync(Stream stream, TransportContext context)
-            {
-                byte[] byteArray = Encoding.ASCII.GetBytes(Content);
-                await stream.WriteAsync(byteArray, 0, Content.Length).ConfigureAwait(false);
-            }
-
-            protected override bool TryComputeLength(out long length)
-            {
-                length = Content.Length;
-                return true;
-            }
-        }
+    [Fact]
+    public async Task Should_Allow_Multiple_Requests_With_Single_HttpClient()
+    {
+        string responseString = @"{
+	    ""Name"": ""Shawn"",
+	    ""Id"": 1
+        }";
+        var api = new MandrillApi("");
+        RespondWith(api, HttpStatusCode.OK, responseString);
+        await api.Post<SampleObject>("", new SamplePayload());
 
     }
+
+    [Fact]
+    public async Task Should_Throw_Mandrill_Exception_When_Serialization_Error()
+    {
+      string responseString = @"<html></html>";
+
+      var api = new MandrillApi("");
+      RespondWith(api, HttpStatusCode.OK, responseString);
+
+      var ex = await Assert.ThrowsAsync<MandrillSerializationException>(async () => await api.Post<object>("", new SamplePayload()));
+      var content = await ex.HttpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+      Assert.Equal(responseString, content);
+    }
+    public class FakeHttpMessageHandler : HttpMessageHandler
+    {
+      private HttpResponseMessage response;
+
+      public FakeHttpMessageHandler(HttpResponseMessage response)
+      {
+        this.response = response;
+      }
+
+      protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+      {
+        var responseTask = new TaskCompletionSource<HttpResponseMessage>();
+        responseTask.SetResult(response);
+
+        return responseTask.Task;
+      }
+    }
+
+    public class FakeHttpContent : HttpContent
+    {
+      public string Content { get; set; }
+
+      public FakeHttpContent(string content)
+      {
+        Content = content;
+      }
+
+      protected async override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+      {
+        byte[] byteArray = Encoding.ASCII.GetBytes(Content);
+        await stream.WriteAsync(byteArray, 0, Content.Length).ConfigureAwait(false);
+      }
+
+      protected override bool TryComputeLength(out long length)
+      {
+        length = Content.Length;
+        return true;
+      }
+    }
+
+  }
 }

--- a/tests/Mandrill.Tests/UnitTests/PostTests.cs
+++ b/tests/Mandrill.Tests/UnitTests/PostTests.cs
@@ -11,125 +11,143 @@ using Xunit;
 
 namespace Mandrill.Tests.UnitTests
 {
-  public class PostTests : IDisposable
-  {
-    public PostTests()
+    public class PostTests : IDisposable
     {
-      var responseMessage = new HttpResponseMessage();
-      var messageHandler = new FakeHttpMessageHandler(responseMessage);
-      httpClient = new HttpClient(messageHandler);
-    }
-    public void Dispose() {
-      httpClient?.Dispose();
-    }
+        public PostTests()
+        {
+            var responseMessage = new HttpResponseMessage();
+            var messageHandler = new FakeHttpMessageHandler(responseMessage);
+            httpClient = new HttpClient(messageHandler);
+        }
+        public void Dispose()
+        {
+            httpClient?.Dispose();
+        }
 
-    private void RespondWith(MandrillApi api, HttpStatusCode statusCode, string content)
-    {
-      var responseMessage = new HttpResponseMessage(statusCode);
-      responseMessage.Content = new FakeHttpContent(content);
-      var messageHandler = new FakeHttpMessageHandler(responseMessage);
-      api.SetHttpClient(new HttpClient(messageHandler));
-    }
+        private void RespondWith(MandrillApi api, HttpStatusCode statusCode, string content)
+        {
+            var responseMessage = new HttpResponseMessage(statusCode);
+            responseMessage.Content = new FakeHttpContent(content);
+            var messageHandler = new FakeHttpMessageHandler(responseMessage);
+            api.SetHttpClient(new HttpClient(messageHandler));
+        }
 
-    private HttpClient httpClient;
+        private HttpClient httpClient;
 
-    private class SampleObject
-    {
-      public string Name { get; set; }
-      public int Id { get; set; }
-    }
+        private class SampleObject
+        {
+            public string Name { get; set; }
+            public int Id { get; set; }
+        }
 
-    private class SamplePayload : RequestBase
-    {
-    }
+        private class SamplePayload : RequestBase
+        {
+        }
 
-    [Fact]
-    public async Task Should_Serialize_Response_When_Json_Content_Is_Recieved()
-    {
-      string responseString = @"{
+        [Fact]
+        public async Task Should_Serialize_Response_When_Json_Content_Is_Recieved()
+        {
+            string responseString = @"{
 	      ""Name"": ""Shawn"",
 	      ""Id"": 1
       }";
-      var api = new MandrillApi("");
-      RespondWith(api, HttpStatusCode.OK, responseString);
+            var api = new MandrillApi("");
+            RespondWith(api, HttpStatusCode.OK, responseString);
 
-      SampleObject response = await api.Post<SampleObject>("", new SamplePayload());
+            SampleObject response = await api.Post<SampleObject>("", new SamplePayload());
 
-      Assert.Equal("Shawn", response.Name);
-      Assert.Equal(1, response.Id);
+            Assert.Equal("Shawn", response.Name);
+            Assert.Equal(1, response.Id);
+        }
+
+        [Fact]
+        public async Task Should_Throw_Mandrill_Exception_When_Server_Error()
+        {
+            string responseString = @"{
+	          ""code"": ""501"",
+	          ""message"": ""m1"",
+	          ""name"": ""n1"",
+	          ""status"": ""s1""
+            }";
+
+            var api = new MandrillApi("");
+            RespondWith(api, HttpStatusCode.InternalServerError, responseString);
+
+            var ex = await Assert.ThrowsAsync<MandrillException>(async () => await api.Post<object>("", new SamplePayload()));
+            Assert.Equal(501, ex.Error.Code);
+            Assert.Equal("m1", ex.Error.Message);
+            Assert.Equal("n1", ex.Error.Name);
+            Assert.Equal("s1", ex.Error.Status);
+        }
+
+        [Fact]
+        public async Task Should_Allow_Multiple_Requests_With_Single_HttpClient()
+        {
+            string responseString = @"{
+	            ""Name"": ""Shawn"",
+	            ""Id"": 1
+            }";
+            var api = new MandrillApi("");
+
+            RespondWith(api, HttpStatusCode.OK, responseString);
+
+            await api.Post<SampleObject>("", new SamplePayload());
+
+            await api.Post<SampleObject>("", new SamplePayload());
+
+        }
+
+        [Fact]
+        public async Task Should_Throw_Mandrill_Exception_When_Serialization_Error()
+        {
+            string responseString = @"<html></html>";
+
+            var api = new MandrillApi("");
+            RespondWith(api, HttpStatusCode.OK, responseString);
+
+            var ex = await Assert.ThrowsAsync<MandrillSerializationException>(async () => await api.Post<object>("", new SamplePayload()));
+            var content = await ex.HttpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+            Assert.Equal(responseString, content);
+        }
+        public class FakeHttpMessageHandler : HttpMessageHandler
+        {
+            private HttpResponseMessage response;
+
+            public FakeHttpMessageHandler(HttpResponseMessage response)
+            {
+                this.response = response;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var responseTask = new TaskCompletionSource<HttpResponseMessage>();
+                responseTask.SetResult(response);
+
+                return responseTask.Task;
+            }
+        }
+
+        public class FakeHttpContent : HttpContent
+        {
+            public string Content { get; set; }
+
+            public FakeHttpContent(string content)
+            {
+                Content = content;
+            }
+
+            protected async override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                byte[] byteArray = Encoding.ASCII.GetBytes(Content);
+                await stream.WriteAsync(byteArray, 0, Content.Length).ConfigureAwait(false);
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = Content.Length;
+                return true;
+            }
+        }
+
     }
-
-    [Fact]
-    public async Task Should_Throw_Mandrill_Exception_When_Server_Error()
-    {
-      string responseString = @"{
-	      ""code"": ""501"",
-	      ""message"": ""m1"",
-	      ""name"": ""n1"",
-	      ""status"": ""s1""
-      }";
-
-      var api = new MandrillApi("");
-      RespondWith(api, HttpStatusCode.InternalServerError, responseString);
-
-      var ex = await Assert.ThrowsAsync<MandrillException>(async () => await api.Post<object>("", new SamplePayload()));
-      Assert.Equal(501, ex.Error.Code);
-      Assert.Equal("m1", ex.Error.Message);
-      Assert.Equal("n1", ex.Error.Name);
-      Assert.Equal("s1", ex.Error.Status);
-    }
-
-    [Fact]
-    public async Task Should_Throw_Mandrill_Exception_When_Serialization_Error()
-    {
-      string responseString = @"<html></html>";
-
-      var api = new MandrillApi("");
-      RespondWith(api, HttpStatusCode.OK, responseString);
-
-      var ex = await Assert.ThrowsAsync<MandrillSerializationException>(async () => await api.Post<object>("", new SamplePayload()));
-      var content = await ex.HttpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
-      Assert.Equal(responseString, content);
-    }
-    public class FakeHttpMessageHandler : HttpMessageHandler
-    {
-      private HttpResponseMessage response;
-
-      public FakeHttpMessageHandler(HttpResponseMessage response)
-      {
-        this.response = response;
-      }
-
-      protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-      {
-        var responseTask = new TaskCompletionSource<HttpResponseMessage>();
-        responseTask.SetResult(response);
-
-        return responseTask.Task;
-      }
-    }
-
-    public class FakeHttpContent : HttpContent
-    {
-      public string Content { get; set; }
-
-      public FakeHttpContent(string content)
-      {
-        Content = content;
-      }
-
-      protected async override Task SerializeToStreamAsync(Stream stream, TransportContext context)
-      {
-        byte[] byteArray = Encoding.ASCII.GetBytes(Content);
-        await stream.WriteAsync(byteArray, 0, Content.Length).ConfigureAwait(false);
-      }
-
-      protected override bool TryComputeLength(out long length)
-      {
-        length = Content.Length;
-        return true;
-      }
-    }
-
-  }
 }


### PR DESCRIPTION
This change:

* Removes the using statement impacting the _httpClient - it will no longer be disposed per request
* Adds a test for this scenario
* Makes some changes with regards to the `BaseAddress` - you cannot change the `BaseAddress` once a request has been flighted. I have changed the public setter on this property. _This is a breaking API change_.
* Had to make some changes to the test helpers with regard to the base address.

RE: Formatting, I've tried to stick with the two-spaces format which was in use... but there may be one or two bits where it's been messed up :/

Fixes #193 