### PR TITLE
Making PreserveRecipients a nullable bool 

### DIFF
--- a/src/Mandrill/Mandrill.csproj
+++ b/src/Mandrill/Mandrill.csproj
@@ -16,6 +16,7 @@
     <Version>1.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 </Project>

--- a/src/Mandrill/Models/EmailMessage.cs
+++ b/src/Mandrill/Models/EmailMessage.cs
@@ -265,7 +265,7 @@ namespace Mandrill.Models
     /// <summary>
     ///   Gets or sets whether or not to expose all recipients in to "To" header for each email.
     /// </summary>
-    public bool PreserveRecipients { get; set; }
+    public bool? PreserveRecipients { get; set; }
 
     /// <summary>
     ///   Gets or sets the raw_message.


### PR DESCRIPTION
so that it defaults to not appearing in the JSON, rather than defaulting to 'false' which has implications about how mandrill treats cc/bcc addresses. see http://blog.mandrill.com/rules-options-easier-bcc.html

