### PR TITLE
ConfigureAwait all the way - Fixes #126

### DIFF
--- a/src/Mandrill/Messages.cs
+++ b/src/Mandrill/Messages.cs
@@ -34,7 +34,7 @@ namespace Mandrill
     {
       string path = "messages/cancel-scheduled.json";
 
-      ScheduledEmailResult resp = await Post<ScheduledEmailResult>(path, request);
+      ScheduledEmailResult resp = await Post<ScheduledEmailResult>(path, request).ConfigureAwait(false);
 
       return resp;
     }
@@ -53,7 +53,7 @@ namespace Mandrill
     {
       string path = "messages/content.json";
 
-      Content response = await Post<Content>(path, request);
+      Content response = await Post<Content>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -68,7 +68,7 @@ namespace Mandrill
     {
       string path = "messages/info.json";
 
-      MessageInfo result = await Post<MessageInfo>(path, request);
+      MessageInfo result = await Post<MessageInfo>(path, request).ConfigureAwait(false);
 
       return result;
     }
@@ -87,7 +87,7 @@ namespace Mandrill
     {
       string path = "messages/list-scheduled.json";
 
-      List<ScheduledEmailResult> resp = await Post<List<ScheduledEmailResult>>(path, request);
+      List<ScheduledEmailResult> resp = await Post<List<ScheduledEmailResult>>(path, request).ConfigureAwait(false);
 
       return resp;
     }
@@ -108,7 +108,7 @@ namespace Mandrill
     {
       string path = "messages/reschedule.json";
 
-      ScheduledEmailResult response = await Post<ScheduledEmailResult>(path, request);
+      ScheduledEmailResult response = await Post<ScheduledEmailResult>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -125,7 +125,7 @@ namespace Mandrill
     {
       const string path = "messages/search.json";
 
-      var response = await Post<List<SearchResult>>(path, request);
+      var response = await Post<List<SearchResult>>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -146,7 +146,7 @@ namespace Mandrill
     {
       string path = "messages/send.json";
 
-      List<EmailResult> resp = await Post<List<EmailResult>>(path, request);
+      List<EmailResult> resp = await Post<List<EmailResult>>(path, request).ConfigureAwait(false);
       return resp;
     }
 
@@ -161,7 +161,7 @@ namespace Mandrill
     {
       string path = "messages/send-template.json";
 
-      List<EmailResult> resp = await Post<List<EmailResult>>(path, request);
+      List<EmailResult> resp = await Post<List<EmailResult>>(path, request).ConfigureAwait(false);
       return resp;
     }
 
@@ -181,7 +181,7 @@ namespace Mandrill
     {
       string path = "messages/send-raw.json";
 
-      List<EmailResult> response = await Post<List<EmailResult>>(path, request);
+      List<EmailResult> response = await Post<List<EmailResult>>(path, request).ConfigureAwait(false);
 
       return response;
     }

--- a/src/Mandrill/Rejects.cs
+++ b/src/Mandrill/Rejects.cs
@@ -31,7 +31,7 @@ namespace Mandrill
     {
       string path = "rejects/add.json";
 
-      RejectAddResult response = await Post<RejectAddResult>(path, request);
+      RejectAddResult response = await Post<RejectAddResult>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -47,7 +47,7 @@ namespace Mandrill
     {
       string path = "rejects/delete.json";
 
-      RejectDeleteResult response = await Post<RejectDeleteResult>(path, request);
+      RejectDeleteResult response = await Post<RejectDeleteResult>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -62,7 +62,7 @@ namespace Mandrill
     {
       string path = "rejects/list.json";
 
-      List<RejectInfo> response = await Post<List<RejectInfo>>(path, request);
+      List<RejectInfo> response = await Post<List<RejectInfo>>(path, request).ConfigureAwait(false);
 
       return response;
     }

--- a/src/Mandrill/Senders.cs
+++ b/src/Mandrill/Senders.cs
@@ -33,7 +33,7 @@ namespace Mandrill
     {
       string path = "senders/check-domain.json";
 
-      SenderDomain response = await Post<SenderDomain>(path, request);
+      SenderDomain response = await Post<SenderDomain>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -48,7 +48,7 @@ namespace Mandrill
     {
       const string path = "senders/list.json";
 
-      List<Sender> response = await Post<List<Sender>>(path, new RequestBase());
+      List<Sender> response = await Post<List<Sender>>(path, new RequestBase()).ConfigureAwait(false);
 
       return response;
     }
@@ -64,7 +64,7 @@ namespace Mandrill
     {
       const string path = "senders/domains.json";
 
-      List<SenderDomain> response = await Post<List<SenderDomain>>(path, new RequestBase());
+      List<SenderDomain> response = await Post<List<SenderDomain>>(path, new RequestBase()).ConfigureAwait(false);
 
       return response;
     }

--- a/src/Mandrill/SubAccounts.cs
+++ b/src/Mandrill/SubAccounts.cs
@@ -19,7 +19,7 @@ namespace Mandrill
     {
       const string path = "subaccounts/add.json";
 
-      SubaccountInfo resp = await Post<SubaccountInfo>(path, request);
+      SubaccountInfo resp = await Post<SubaccountInfo>(path, request).ConfigureAwait(false);
 
       return resp;
     }
@@ -36,7 +36,7 @@ namespace Mandrill
     {
       const string path = "subaccounts/delete.json";
 
-      SubaccountInfo resp = await Post<SubaccountInfo>(path, request);
+      SubaccountInfo resp = await Post<SubaccountInfo>(path, request).ConfigureAwait(false);
 
       return resp;
     }
@@ -52,7 +52,7 @@ namespace Mandrill
     {
       const string path = "subaccounts/list.json";
 
-      List<SubaccountInfo> resp = await Post<List<SubaccountInfo>>(path, request);
+      List<SubaccountInfo> resp = await Post<List<SubaccountInfo>>(path, request).ConfigureAwait(false);
 
       return resp;
     }
@@ -68,7 +68,7 @@ namespace Mandrill
     {
       const string path = "subaccounts/pause.json";
 
-      SubaccountInfo resp = await Post<SubaccountInfo>(path, request);
+      SubaccountInfo resp = await Post<SubaccountInfo>(path, request).ConfigureAwait(false);
 
       return resp;
     }
@@ -83,7 +83,7 @@ namespace Mandrill
     {
       const string path = "subaccounts/resume.json";
 
-      SubaccountInfo response = await Post<SubaccountInfo>(path, request);
+      SubaccountInfo response = await Post<SubaccountInfo>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -98,7 +98,7 @@ namespace Mandrill
     {
       const string path = "subaccounts/info.json";
 
-      SubaccountInfo response = await Post<SubaccountInfo>(path, request);
+      SubaccountInfo response = await Post<SubaccountInfo>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -113,7 +113,7 @@ namespace Mandrill
     {
       const string path = "subaccounts/update.json";
 
-      SubaccountInfo response = await Post<SubaccountInfo>(path, request);
+      SubaccountInfo response = await Post<SubaccountInfo>(path, request).ConfigureAwait(false);
 
       return response;
     }

--- a/src/Mandrill/Templates.cs
+++ b/src/Mandrill/Templates.cs
@@ -32,7 +32,7 @@ namespace Mandrill
     {
       string path = "templates/add.json";
 
-      TemplateInfo resp = await Post<TemplateInfo>(path, request);
+      TemplateInfo resp = await Post<TemplateInfo>(path, request).ConfigureAwait(false);
 
       return resp;
     }
@@ -47,7 +47,7 @@ namespace Mandrill
     {
       const string path = "templates/list.json";
 
-      List<TemplateInfo> resp = await Post<List<TemplateInfo>>(path, request);
+      List<TemplateInfo> resp = await Post<List<TemplateInfo>>(path, request).ConfigureAwait(false);
 
       return resp;
     }
@@ -65,7 +65,7 @@ namespace Mandrill
     {
       const string path = "templates/render.json";
 
-      RenderedTemplate response = await Post<RenderedTemplate>(path, request);
+      RenderedTemplate response = await Post<RenderedTemplate>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -86,7 +86,7 @@ namespace Mandrill
     {
       const string path = "templates/update.json";
 
-      TemplateInfo response = await Post<TemplateInfo>(path, request);
+      TemplateInfo response = await Post<TemplateInfo>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -104,7 +104,7 @@ namespace Mandrill
     {
       const string path = "templates/delete.json";
 
-      TemplateInfo response = await Post<TemplateInfo>(path, request);
+      TemplateInfo response = await Post<TemplateInfo>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -122,7 +122,7 @@ namespace Mandrill
     {
       const string path = "templates/info.json";
 
-      TemplateInfo response = await Post<TemplateInfo>(path, request);
+      TemplateInfo response = await Post<TemplateInfo>(path, request).ConfigureAwait(false);
 
       return response;
     }
@@ -140,7 +140,7 @@ namespace Mandrill
     {
       const string path = "templates/time-series.json";
 
-      List<TemplateTimeSeries> response = await Post<List<TemplateTimeSeries>>(path, request);
+      List<TemplateTimeSeries> response = await Post<List<TemplateTimeSeries>>(path, request).ConfigureAwait(false);
 
       return response;
     }

--- a/src/Mandrill/Users.cs
+++ b/src/Mandrill/Users.cs
@@ -31,7 +31,7 @@ namespace Mandrill
     {
       var path = "users/ping.json";
 
-      var response = await Post<string>(path, new RequestBase());
+      var response = await Post<string>(path, new RequestBase()).ConfigureAwait(false);
 
       return response;
     }


### PR DESCRIPTION
The work for #126 added `.ConfigureAwait(false)` to a single call, but it was required in more places to prevent deadlocks.