### PR TITLE
Use the JSON utility so we get the custom serialization settings. Fixes #198

### DIFF
--- a/src/Mandrill/MandrillApi.cs
+++ b/src/Mandrill/MandrillApi.cs
@@ -151,7 +151,7 @@ namespace Mandrill
           string requestContent;
           try
           {
-            requestContent = JsonConvert.SerializeObject(data);
+            requestContent = JSON.Serialize(data);
           }
           catch (JsonException ex)
           {


### PR DESCRIPTION
Without the `JSON.Serialize` utility method we aren't serializing the data properly when we send it up to Mandrill.

We send this:

```
{
    "message": {
        "Attachments": null,
        "AutoHtml": null,
        "AutoText": null,
        "BccAddress": null,
        "FromEmail": null,
        "FromName": null,
        "GlobalMergeVars": [
```

Not this:

```
{
    "message": {
        "attachments": null,
        "auto_html": null,
        "auto_text": null,
        "bcc_address": null,
        "from_email": "support@email.com",
        "from_name": "Mista Ree",
        "global_merge_vars": [
```