### PR TITLE
Add support for SendersInfo API route

### DIFF
--- a/src/Mandrill/IMandrillApi.cs
+++ b/src/Mandrill/IMandrillApi.cs
@@ -131,6 +131,15 @@ namespace Mandrill
     Task<List<Sender>> ListSenders();
 
     /// <summary>
+    ///  The sender info.
+    /// </summary>
+    /// <param name="request">The sender info request.</param>
+    /// <returns>
+    ///  a <see cref="Sender" />
+    /// </returns>
+    Task<Sender> SenderInfo(SenderInfoRequest request);
+
+    /// <summary>
     ///   The list senders.
     /// </summary>
     /// <returns>

--- a/src/Mandrill/Models/Sender.cs
+++ b/src/Mandrill/Models/Sender.cs
@@ -68,6 +68,11 @@ namespace Mandrill.Models
     /// </summary>
     public int Unsubs { get; set; }
 
+    /// <summary>
+    ///   Gets or sets the stats.
+    /// </summary>
+    public Stats Stats { get; set; }
+
     #endregion
   }
 }

--- a/src/Mandrill/Models/UserInfo.cs
+++ b/src/Mandrill/Models/UserInfo.cs
@@ -21,26 +21,31 @@ namespace Mandrill.Models
     /// <summary>
     ///   The all_time.
     /// </summary>
+    [JsonProperty("all_time")]
     public UserInfoStats AllTime { get; set; }
 
     /// <summary>
     ///   The last_30_days.
     /// </summary>
+    [JsonProperty("last_30_days")]
     public UserInfoStats Last30Days { get; set; }
 
     /// <summary>
     ///   The last_60_days.
     /// </summary>
+    [JsonProperty("last_60_days")]
     public UserInfoStats Last60Days { get; set; }
 
     /// <summary>
     ///   The last_7_days.
     /// </summary>
+    [JsonProperty("last_7_days")]
     public UserInfoStats Last7Days { get; set; }
 
     /// <summary>
     ///   The last_90_days.
     /// </summary>
+    [JsonProperty("last_90_days")]
     public UserInfoStats Last90Days { get; set; }
 
     /// <summary>

--- a/src/Mandrill/Requests/Senders/SenderInfoRequest.cs
+++ b/src/Mandrill/Requests/Senders/SenderInfoRequest.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Mandrill.Requests.Senders
+{
+  public class SenderInfoRequest : RequestBase
+  {
+    public SenderInfoRequest(string address)
+    {
+       Address = address;
+    }
+
+    [JsonProperty("address")]
+    public string Address { get; set; }
+  }
+}

--- a/src/Mandrill/Senders.cs
+++ b/src/Mandrill/Senders.cs
@@ -53,6 +53,20 @@ namespace Mandrill
       return response;
     }
 
+    /// <summary>
+    ///   The sender info.
+    /// </summary>
+    /// <returns>
+    ///   The <see cref="Sender" />
+    /// </returns>
+    public async Task<Sender> SenderInfo(SenderInfoRequest request)
+    {
+      const string path = "senders/info.json";
+
+      Sender response = await Post<Sender>(path, request).ConfigureAwait(false);
+    
+      return response;
+    }
 
     /// <summary>
     ///   The list senders.

--- a/tests/Mandrill.Tests/IntegrationTests/Senders/SenderInfoTests.cs
+++ b/tests/Mandrill.Tests/IntegrationTests/Senders/SenderInfoTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Mandrill.Models;
+using Mandrill.Requests.Senders;
+using Xunit;
+
+namespace Mandrill.Tests.IntegrationTests.Senders
+{
+  [TestFixture]
+  public class SenderInfoTests
+  {
+    [Test]
+    public async Task Should_Return_Sender()
+    {
+        // Setup
+        string apiKey = ConfigurationManager.AppSettings["APIKey"];
+        
+        // Exercise
+        var api = new MandrillApi(apiKey);
+
+        // Verify
+        Sender sender = await api.SenderInfo(new SenderInfoRequest("testaddress@test.com"));
+
+        Assert.IsNotNull(sender);
+    }
+  }
+}


### PR DESCRIPTION
Add support to get data for a specific sender from the API (documentation [is here](https://mandrillapp.com/api/docs/senders.JSON.html#method=info))

Let me know if there's anything more I can do -- wasn't sure how this repo likes contributions but tried to match my styling/code/tests/etc. to the rest of the repo.